### PR TITLE
Ruby2.5 compat (and some... maintenance...)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 require: rubocop-rspec
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   Include:
     - ./**/*.rb
     - '**/Rakefile'

--- a/Gemfile
+++ b/Gemfile
@@ -3,52 +3,60 @@
 source 'https://rubygems.org'
 
 # core
-gem 'bcrypt'
-gem 'sinatra'
-gem 'sinatra-contrib'
-gem 'sshkey'
+gem 'bcrypt', '~> 3.1'
+gem 'sinatra', '~> 2.0.1'
+gem 'sinatra-contrib', '~> 2.0.1'
+gem 'sshkey', '~> 1.9.0'
+
 # tools
-gem 'rake', require: false
+gem 'rake', '~> 12.0', require: false
+
 # authorization
-gem 'sinatra-pundit'
+# gem 'sinatra-pundit', '~> 0.1.0'
+gem 'sinatra-pundit', git: 'https://github.com/vhost-api/sinatra-pundit.git'
+
 # database
-gem 'data_mapper'
+gem 'data_mapper', '~> 1.2.0'
+gem 'data_objects', git: 'https://github.com/vhost-api/do.git', submodules: true
+gem 'dm-constraints', '~> 1.2.0'
 
 group :mysql do
-  gem 'dm-mysql-adapter'
+  gem 'dm-mysql-adapter', '~> 1.2.0'
+  gem 'do_mysql', '~> 0.10.17'
 end
 
 group :postgres do
-  gem 'dm-postgres-adapter'
+  gem 'dm-postgres-adapter', '~> 1.2.0'
+  gem 'do_postgres', '~> 0.10.17'
 end
 
-gem 'dm-constraints'
 # engine
-gem 'puma'
+gem 'puma', '~> 3.11'
+
 # style
-gem 'activesupport'
-gem 'filesize'
+gem 'activesupport', '~> 5.1.5'
+gem 'filesize', '~> 0.1.1'
 
 group :development do
-  gem 'better_errors'
-  gem 'binding_of_caller'
-  gem 'guard', require: false
-  gem 'guard-rspec', require: false
-  gem 'pry'
-  gem 'shotgun', require: false
+  gem 'better_errors', '~> 2.4.0'
+  gem 'binding_of_caller', '~> 0.8.0'
+  gem 'guard', '~> 2.14.2', require: false
+  gem 'guard-rspec', '~> 4.7.3', require: false
+  gem 'pry', '~> 0.11.3'
+  gem 'shotgun', '~> 0.9.2', require: false
 end
 
 group :test, :development do
-  gem 'astrolabe', require: false
-  gem 'faker', require: false
-  gem 'rspec', require: false
-  gem 'rubocop', require: false
-  gem 'rubocop-rspec', require: false
-  gem 'simplecov', require: false
-  gem 'yard', require: false
+  gem 'astrolabe', '~> 1.3.1', require: false
+  gem 'faker', '~> 1.8.7', require: false
+  gem 'rspec', '~> 3.7.0', require: false
+  gem 'rubocop', '~> 0.54.0', require: false
+  gem 'rubocop-rspec', '~> 1.24.0', require: false
+  gem 'simplecov', '~> 0.16.1', require: false
+  gem 'yard', '~> 0.9.12', require: false
 end
 
 group :test do
-  gem 'database_cleaner'
-  gem 'factory_girl'
+  gem 'database_cleaner', '~> 1.6.2'
+  gem 'factory_girl', '~> 4.9.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -17,17 +17,14 @@ gem 'sinatra-pundit', git: 'https://github.com/vhost-api/sinatra-pundit.git'
 
 # database
 gem 'data_mapper', '~> 1.2.0'
-gem 'data_objects', git: 'https://github.com/vhost-api/do.git', submodules: true
 gem 'dm-constraints', '~> 1.2.0'
 
 group :mysql do
   gem 'dm-mysql-adapter', '~> 1.2.0'
-  gem 'do_mysql', '~> 0.10.17'
 end
 
 group :postgres do
   gem 'dm-postgres-adapter', '~> 1.2.0'
-  gem 'do_postgres', '~> 0.10.17'
 end
 
 # engine
@@ -59,5 +56,5 @@ end
 
 group :test do
   gem 'database_cleaner', '~> 1.6.2'
-  gem 'factory_girl', '~> 4.9.0'
+  gem 'factory_bot', '~> 4.8.2'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ end
 group :test, :development do
   gem 'astrolabe', '~> 1.3.1', require: false
   gem 'faker', '~> 1.8.7', require: false
+  gem 'rack-test', '~> 0.8.3', require: false
   gem 'rspec', '~> 3.7.0', require: false
   gem 'rubocop', '~> 0.54.0', require: false
   gem 'rubocop-rspec', '~> 1.24.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,37 @@
+GIT
+  remote: https://github.com/vhost-api/do.git
+  revision: d87bac0f0b700876307db3aa9beba7ff0decbd2d
+  submodules: true
+  specs:
+    data_objects (0.10.17)
+      addressable (~> 2.1)
+    do_mysql (0.10.17)
+      data_objects (= 0.10.17)
+    do_postgres (0.10.17)
+      data_objects (= 0.10.17)
+
+GIT
+  remote: https://github.com/vhost-api/sinatra-pundit.git
+  revision: 3f63a53aa1ddc857c2e68f1c8cfc65c8d17a6a09
+  specs:
+    sinatra-pundit (0.1.0)
+      pundit (~> 1.0)
+      sinatra (>= 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.4)
+    activesupport (5.1.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    ast (2.3.0)
+    ast (2.4.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    backports (3.10.3)
+    backports (3.11.1)
     bcrypt (3.1.11)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
@@ -19,7 +39,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    binding_of_caller (0.7.3)
+    binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -33,8 +53,6 @@ GEM
       dm-transactions (~> 1.2.0)
       dm-types (~> 1.2.0)
       dm-validations (~> 1.2.0)
-    data_objects (0.10.17)
-      addressable (~> 2.1)
     database_cleaner (1.6.2)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
@@ -75,24 +93,20 @@ GEM
       uuidtools (~> 2.1)
     dm-validations (1.2.0)
       dm-core (~> 1.2.0)
-    do_mysql (0.10.17)
-      data_objects (= 0.10.17)
-    do_postgres (0.10.17)
-      data_objects (= 0.10.17)
-    docile (1.1.5)
-    erubi (1.7.0)
+    docile (1.3.0)
+    erubi (1.7.1)
     factory_girl (4.9.0)
       activesupport (>= 3.0.0)
-    faker (1.8.4)
-      i18n (~> 0.5)
+    faker (1.8.7)
+      i18n (>= 0.7)
     fastercsv (1.5.5)
-    ffi (1.9.18)
+    ffi (1.9.23)
     filesize (0.1.1)
     formatador (0.2.5)
-    guard (2.14.1)
+    guard (2.14.2)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
-      lumberjack (~> 1.0)
+      lumberjack (>= 1.0.12, < 2.0)
       nenv (~> 0.1)
       notiffany (~> 0.0)
       pry (>= 0.9.12)
@@ -103,7 +117,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    i18n (0.9.1)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (1.8.6)
     json_pure (1.8.6)
@@ -113,39 +127,37 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.12)
     method_source (0.9.0)
-    minitest (5.10.3)
-    multi_json (1.12.2)
+    minitest (5.11.3)
+    multi_json (1.13.1)
+    mustermann (1.0.2)
     nenv (0.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    parallel (1.12.0)
-    parser (2.4.0.2)
-      ast (~> 2.3)
+    parallel (1.12.1)
+    parser (2.5.0.5)
+      ast (~> 2.4.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.1)
-    puma (3.11.0)
+    public_suffix (3.0.2)
+    puma (3.11.3)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
-    rack (1.6.8)
-    rack-protection (1.5.3)
+    rack (2.0.4)
+    rack-protection (2.0.1)
       rack
-    rack-test (0.8.2)
-      rack (>= 1.0, < 3)
-    rainbow (2.2.2)
-      rake
-    rake (12.3.0)
-    rb-fsevent (0.10.2)
+    rainbow (3.0.0)
+    rake (12.3.1)
+    rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
       rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.0)
+    rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -153,83 +165,84 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
-    rspec-support (3.7.0)
-    rubocop (0.51.0)
+    rspec-support (3.7.1)
+    rubocop (0.54.0)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.5)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.20.1)
-      rubocop (>= 0.51.0)
+    rubocop-rspec (1.24.0)
+      rubocop (>= 0.53.0)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     shellany (0.0.1)
     shotgun (0.9.2)
       rack (>= 1.0)
-    simplecov (0.15.1)
-      docile (~> 1.1.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (1.4.8)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
-    sinatra-contrib (1.4.7)
+    sinatra (2.0.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.1)
+      tilt (~> 2.0)
+    sinatra-contrib (2.0.1)
       backports (>= 2.0)
       multi_json
-      rack-protection
-      rack-test
-      sinatra (~> 1.4.0)
+      mustermann (~> 1.0)
+      rack-protection (= 2.0.1)
+      sinatra (= 2.0.1)
       tilt (>= 1.3, < 3)
-    sinatra-pundit (0.1.0)
-      pundit (~> 1.0)
-      sinatra (~> 1.0)
     sshkey (1.9.0)
     stringex (1.5.1)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
     uuidtools (2.1.5)
-    yard (0.9.11)
+    yard (0.9.12)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
-  astrolabe
-  bcrypt
-  better_errors
-  binding_of_caller
-  data_mapper
-  database_cleaner
-  dm-constraints
-  dm-mysql-adapter
-  dm-postgres-adapter
-  factory_girl
-  faker
-  filesize
-  guard
-  guard-rspec
-  pry
-  puma
-  rake
-  rspec
-  rubocop
-  rubocop-rspec
-  shotgun
-  simplecov
-  sinatra
-  sinatra-contrib
-  sinatra-pundit
-  sshkey
-  yard
+  activesupport (~> 5.1.5)
+  astrolabe (~> 1.3.1)
+  bcrypt (~> 3.1)
+  better_errors (~> 2.4.0)
+  binding_of_caller (~> 0.8.0)
+  data_mapper (~> 1.2.0)
+  data_objects!
+  database_cleaner (~> 1.6.2)
+  dm-constraints (~> 1.2.0)
+  dm-mysql-adapter (~> 1.2.0)
+  dm-postgres-adapter (~> 1.2.0)
+  do_mysql (~> 0.10.17)
+  do_postgres (~> 0.10.17)
+  factory_girl (~> 4.9.0)
+  faker (~> 1.8.7)
+  filesize (~> 0.1.1)
+  guard (~> 2.14.2)
+  guard-rspec (~> 4.7.3)
+  pry (~> 0.11.3)
+  puma (~> 3.11)
+  rake (~> 12.0)
+  rspec (~> 3.7.0)
+  rubocop (~> 0.54.0)
+  rubocop-rspec (~> 1.24.0)
+  shotgun (~> 0.9.2)
+  simplecov (~> 0.16.1)
+  sinatra (~> 2.0.1)
+  sinatra-contrib (~> 2.0.1)
+  sinatra-pundit!
+  sshkey (~> 1.9.0)
+  yard (~> 0.9.12)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
     rack (2.0.4)
     rack-protection (2.0.1)
       rack
+    rack-test (0.8.3)
+      rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rake (12.3.1)
     rb-fsevent (0.10.3)
@@ -232,6 +234,7 @@ DEPENDENCIES
   guard-rspec (~> 4.7.3)
   pry (~> 0.11.3)
   puma (~> 3.11)
+  rack-test (~> 0.8.3)
   rake (~> 12.0)
   rspec (~> 3.7.0)
   rubocop (~> 0.54.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,4 @@
 GIT
-  remote: https://github.com/vhost-api/do.git
-  revision: d87bac0f0b700876307db3aa9beba7ff0decbd2d
-  submodules: true
-  specs:
-    data_objects (0.10.17)
-      addressable (~> 2.1)
-    do_mysql (0.10.17)
-      data_objects (= 0.10.17)
-    do_postgres (0.10.17)
-      data_objects (= 0.10.17)
-
-GIT
   remote: https://github.com/vhost-api/sinatra-pundit.git
   revision: 3f63a53aa1ddc857c2e68f1c8cfc65c8d17a6a09
   specs:
@@ -53,6 +41,8 @@ GEM
       dm-transactions (~> 1.2.0)
       dm-types (~> 1.2.0)
       dm-validations (~> 1.2.0)
+    data_objects (0.10.17)
+      addressable (~> 2.1)
     database_cleaner (1.6.2)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
@@ -93,9 +83,13 @@ GEM
       uuidtools (~> 2.1)
     dm-validations (1.2.0)
       dm-core (~> 1.2.0)
+    do_mysql (0.10.17)
+      data_objects (= 0.10.17)
+    do_postgres (0.10.17)
+      data_objects (= 0.10.17)
     docile (1.3.0)
     erubi (1.7.1)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
     faker (1.8.7)
       i18n (>= 0.7)
@@ -220,14 +214,11 @@ DEPENDENCIES
   better_errors (~> 2.4.0)
   binding_of_caller (~> 0.8.0)
   data_mapper (~> 1.2.0)
-  data_objects!
   database_cleaner (~> 1.6.2)
   dm-constraints (~> 1.2.0)
   dm-mysql-adapter (~> 1.2.0)
   dm-postgres-adapter (~> 1.2.0)
-  do_mysql (~> 0.10.17)
-  do_postgres (~> 0.10.17)
-  factory_girl (~> 4.9.0)
+  factory_bot (~> 4.8.2)
   faker (~> 1.8.7)
   filesize (~> 0.1.1)
   guard (~> 2.14.2)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ services to it while retaining some pre-existing configs/setups.
 
 1. Clone the git repository to a location of your choice
 2. Depending on whether you want to use MySQL or PostgreSQL for the database:
-   run either `bundle install --path vendor/bundle --without postgres development test` or `bundle install --path vendor/bundle --without mysql development test`
+   run either `bundle install --path .vendor/bundle --without postgres development test` or `bundle install --path .vendor/bundle --without mysql development test`
 3. Prepare an empty database with user and password
 4. Copy example configs for `appconfig.yml` and `database.yml` from `config/*.example.yml` to `config/` and adjust to your preferences
 5. Setup the database layout by running `RACK_ENV="production" bundle exec rake db:migrate`
@@ -91,7 +91,7 @@ Take the following hints into consideration and adjust to your preferences:
 ### Development setup
 
 + Prepend `RACK_ENV="development"` for most stuff to set up the environment correctly
-+ Install development and test gems by running `bundle install --path vendor/bundle --with development test`
++ Install development and test gems by running `bundle install --path .vendor/bundle --with development test`
 + Run the application via `RACK_ENV="development" bundle exec shotgun config.ru` to enable auto-reloading of all files at runtime
 + To empty the database simply run `RACK_ENV="development" bundle exec rake db:reset` and you can load your seed data once again
 

--- a/app/controllers/api/v1/apikey_controller.rb
+++ b/app/controllers/api/v1/apikey_controller.rb
@@ -95,7 +95,7 @@ namespace '/api/v1/apikeys' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/apikey_controller.rb
+++ b/app/controllers/api/v1/apikey_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/apikeys' do
   get do
     @apikeys = policy_scope(Apikey)
@@ -79,7 +80,7 @@ namespace '/api/v1/apikeys' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -226,7 +227,7 @@ namespace '/api/v1/apikeys' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -267,3 +268,4 @@ namespace '/api/v1/apikeys' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/dkim_controller.rb
+++ b/app/controllers/api/v1/dkim_controller.rb
@@ -112,7 +112,7 @@ namespace '/api/v1/dkims' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/dkim_controller.rb
+++ b/app/controllers/api/v1/dkim_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/dkims' do
   helpers do
     # @return [String, String]
@@ -96,7 +97,7 @@ namespace '/api/v1/dkims' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -237,7 +238,7 @@ namespace '/api/v1/dkims' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -270,3 +271,4 @@ namespace '/api/v1/dkims' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/dkimsigning_controller.rb
+++ b/app/controllers/api/v1/dkimsigning_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/dkimsignings' do
   get do
     @dkimsignings = policy_scope(DkimSigning)
@@ -76,7 +77,7 @@ namespace '/api/v1/dkimsignings' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -218,7 +219,7 @@ namespace '/api/v1/dkimsignings' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -241,3 +242,4 @@ namespace '/api/v1/dkimsignings' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/dkimsigning_controller.rb
+++ b/app/controllers/api/v1/dkimsigning_controller.rb
@@ -92,7 +92,7 @@ namespace '/api/v1/dkimsignings' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/domain_controller.rb
+++ b/app/controllers/api/v1/domain_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/domains' do
   get do
     @domains = policy_scope(Domain)
@@ -70,7 +71,7 @@ namespace '/api/v1/domains' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -202,7 +203,7 @@ namespace '/api/v1/domains' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -222,3 +223,4 @@ namespace '/api/v1/domains' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/domain_controller.rb
+++ b/app/controllers/api/v1/domain_controller.rb
@@ -86,7 +86,7 @@ namespace '/api/v1/domains' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/group_controller.rb
+++ b/app/controllers/api/v1/group_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/groups' do
   get do
     @groups = policy_scope(Group)
@@ -67,7 +68,7 @@ namespace '/api/v1/groups' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -196,7 +197,7 @@ namespace '/api/v1/groups' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -216,3 +217,4 @@ namespace '/api/v1/groups' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/group_controller.rb
+++ b/app/controllers/api/v1/group_controller.rb
@@ -83,7 +83,7 @@ namespace '/api/v1/groups' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/ipv4address_controller.rb
+++ b/app/controllers/api/v1/ipv4address_controller.rb
@@ -11,7 +11,7 @@ namespace '/api/v1/ipv4addresses' do
     return_resource object: @ipv4address
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/ipv6address_controller.rb
+++ b/app/controllers/api/v1/ipv6address_controller.rb
@@ -11,7 +11,7 @@ namespace '/api/v1/ipv6addresses' do
     return_resource object: @ipv6address
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/mailaccount_controller.rb
+++ b/app/controllers/api/v1/mailaccount_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/mailaccounts' do
   helpers do
     # @return [String]
@@ -135,7 +136,7 @@ namespace '/api/v1/mailaccounts' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -354,7 +355,7 @@ namespace '/api/v1/mailaccounts' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -381,7 +382,7 @@ namespace '/api/v1/mailaccounts' do
       file = sieve_filename
       content_type 'application/octet-stream'
       send_file(file,
-                disposition: 'attachment'.dup,
+                disposition: +'attachment',
                 filename: File.basename(file))
     end
 
@@ -446,7 +447,7 @@ namespace '/api/v1/mailaccounts' do
         file.close!
 
         return_apiresponse(ApiResponseSuccess.new)
-      rescue => err
+      rescue Error => err
         # cleanup tempfile
         file.unlink
         file.close!
@@ -464,3 +465,4 @@ namespace '/api/v1/mailaccounts' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/mailaccount_controller.rb
+++ b/app/controllers/api/v1/mailaccount_controller.rb
@@ -151,7 +151,7 @@ namespace '/api/v1/mailaccounts' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/mailalias_controller.rb
+++ b/app/controllers/api/v1/mailalias_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/mailaliases' do
   get do
     @mailaliases = policy_scope(MailAlias)
@@ -95,7 +96,7 @@ namespace '/api/v1/mailaliases' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -264,7 +265,7 @@ namespace '/api/v1/mailaliases' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -285,3 +286,4 @@ namespace '/api/v1/mailaliases' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/mailalias_controller.rb
+++ b/app/controllers/api/v1/mailalias_controller.rb
@@ -111,7 +111,7 @@ namespace '/api/v1/mailaliases' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/mailforwarding_controller.rb
+++ b/app/controllers/api/v1/mailforwarding_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/mailforwardings' do
   get do
     @mailforwardings = policy_scope(MailForwarding)
@@ -80,7 +81,7 @@ namespace '/api/v1/mailforwardings' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -241,7 +242,7 @@ namespace '/api/v1/mailforwardings' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -263,3 +264,4 @@ namespace '/api/v1/mailforwardings' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/mailforwarding_controller.rb
+++ b/app/controllers/api/v1/mailforwarding_controller.rb
@@ -96,7 +96,7 @@ namespace '/api/v1/mailforwardings' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/mailsource_controller.rb
+++ b/app/controllers/api/v1/mailsource_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/mailsources' do
   get do
     @mailsources = policy_scope(MailSource)
@@ -95,7 +96,7 @@ namespace '/api/v1/mailsources' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -265,7 +266,7 @@ namespace '/api/v1/mailsources' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -286,3 +287,4 @@ namespace '/api/v1/mailsources' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/mailsource_controller.rb
+++ b/app/controllers/api/v1/mailsource_controller.rb
@@ -111,7 +111,7 @@ namespace '/api/v1/mailsources' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/package_controller.rb
+++ b/app/controllers/api/v1/package_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/packages' do
   get do
     @packages = policy_scope(Package)
@@ -70,7 +71,7 @@ namespace '/api/v1/packages' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -196,7 +197,7 @@ namespace '/api/v1/packages' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -217,3 +218,4 @@ namespace '/api/v1/packages' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/package_controller.rb
+++ b/app/controllers/api/v1/package_controller.rb
@@ -86,7 +86,7 @@ namespace '/api/v1/packages' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/phpruntime_controller.rb
+++ b/app/controllers/api/v1/phpruntime_controller.rb
@@ -11,7 +11,7 @@ namespace '/api/v1/phpruntimes' do
     return_resource object: @phpruntime
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/sftpuser_controller.rb
+++ b/app/controllers/api/v1/sftpuser_controller.rb
@@ -11,7 +11,7 @@ namespace '/api/v1/sftpusers' do
     return_resource object: @sftpuser
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/shelluser_controller.rb
+++ b/app/controllers/api/v1/shelluser_controller.rb
@@ -11,7 +11,7 @@ namespace '/api/v1/shellusers' do
     return_resource object: @shelluser
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/user_controller.rb
+++ b/app/controllers/api/v1/user_controller.rb
@@ -108,7 +108,7 @@ namespace '/api/v1/users' do
     return_apiresponse @result
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/controllers/api/v1/user_controller.rb
+++ b/app/controllers/api/v1/user_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 namespace '/api/v1/users' do
   get do
     @users = policy_scope(User)
@@ -92,7 +93,7 @@ namespace '/api/v1/users' do
                 else
                   api_error(ApiErrors.[](:malformed_request))
                 end
-    rescue => err
+    rescue Error => err
       # unhandled error, always log backtrace
       log_user('error', err.message)
       log_user('error', err.backtrace.join("\n"))
@@ -237,7 +238,7 @@ namespace '/api/v1/users' do
                   else
                     api_error(ApiErrors.[](:malformed_request))
                   end
-      rescue => err
+      rescue Error => err
         # unhandled error, always log backtrace
         log_user('error', err.message)
         log_user('error', err.backtrace.join("\n"))
@@ -299,3 +300,4 @@ namespace '/api/v1/users' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/app/controllers/api/v1/vhost_controller.rb
+++ b/app/controllers/api/v1/vhost_controller.rb
@@ -11,7 +11,7 @@ namespace '/api/v1/vhosts' do
     return_resource object: @vhost
   end
 
-  before %r{\A/(?<id>\d+)/?.*} do
+  before %r{/(?<id>\d+)/?.*} do
     # namespace local before blocks are evaluate before global before blocks
     # thus we need to enforce authentication here
     authenticate! if @user.nil?

--- a/app/helpers/controller_helper.rb
+++ b/app/helpers/controller_helper.rb
@@ -33,7 +33,7 @@ def return_authorized_collection(object: nil, params: { fields: nil })
     object = limited_collection(collection: object, params: params)
   rescue DataObjects::DataError, ArgumentError
     return_api_error(ApiErrors.[](:invalid_query))
-  rescue => err
+  rescue Error => err
     log_app('error', "#{err.message}\n#{err.backtrace}")
     return_api_error(ApiErrors.[](:invalid_request))
   end
@@ -88,9 +88,9 @@ end
 def search_collection(collection: nil, query: nil)
   return collection if query.nil?
   query.keys.each do |key|
-    search_query = if key.to_s =~ %r{enabled$}
+    search_query = if key.match?('enabled')
                      { key => string_to_bool(query[key]) }
-                   elsif key.to_s =~ %r{_id$}
+                   elsif key.ends_with?('_id')
                      { key => query[key].to_i }
                    else
                      { key.like => "%#{query[key]}%" }

--- a/app/helpers/controller_helper.rb
+++ b/app/helpers/controller_helper.rb
@@ -90,7 +90,7 @@ def search_collection(collection: nil, query: nil)
   query.keys.each do |key|
     search_query = if key.match?('enabled')
                      { key => string_to_bool(query[key]) }
-                   elsif key.ends_with?('_id')
+                   elsif key.to_s.end_with?('_id')
                      { key => query[key].to_i }
                    else
                      { key.like => "%#{query[key]}%" }

--- a/app/models/mailaccount.rb
+++ b/app/models/mailaccount.rb
@@ -113,3 +113,4 @@ class MailAccount
      settings.sieve_file].join('/')
   end
 end
+# rubocop:enable Metrics/LineLength

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -54,3 +54,4 @@ class Package
     { id: user.id, name: user.name, login: user.login }
   end
 end
+# rubocop:enable Metrics/LineLength

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,11 +51,7 @@ class User
   def authenticate(attempted_password)
     # BCrypt automatically hashes the right side of ==
     # when comparing to self.password.
-    if password == attempted_password
-      true
-    else
-      false
-    end
+    password == attempted_password
   end
 
   # @param options [Hash]

--- a/app/models/vhost.rb
+++ b/app/models/vhost.rb
@@ -71,3 +71,4 @@ class Vhost
     user
   end
 end
+# rubocop:enable Metrics/LineLength

--- a/app/policies/apikey_policy.rb
+++ b/app/policies/apikey_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for ApiKey
 class ApikeyPolicy < ApplicationPolicy

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -94,6 +94,7 @@ class ApplicationPolicy
       @errors = []
     end
 
+    # rubocop:disable Lint/DuplicateMethods
     def attributes
       if record.is_a?(Array)
         record.properties.map(&:name)
@@ -101,6 +102,7 @@ class ApplicationPolicy
         record.class.properties.map(&:name)
       end
     end
+    # rubocop:enable Lint/DuplicateMethods
   end
 
   private

--- a/app/policies/database_policy.rb
+++ b/app/policies/database_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for Database
 class DatabasePolicy < ApplicationPolicy

--- a/app/policies/databaseuser_policy.rb
+++ b/app/policies/databaseuser_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for DatabaseUser
 class DatabaseUserPolicy < ApplicationPolicy

--- a/app/policies/dkim_policy.rb
+++ b/app/policies/dkim_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for Dkim
 class DkimPolicy < ApplicationPolicy

--- a/app/policies/dkimsigning_policy.rb
+++ b/app/policies/dkimsigning_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for DkimSigning
 class DkimSigningPolicy < ApplicationPolicy

--- a/app/policies/domain_policy.rb
+++ b/app/policies/domain_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for Domain
 class DomainPolicy < ApplicationPolicy

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for Group
 class GroupPolicy < ApplicationPolicy

--- a/app/policies/ipv4address_policy.rb
+++ b/app/policies/ipv4address_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for Ipv4Address
 class Ipv4AddressPolicy < ApplicationPolicy

--- a/app/policies/ipv6address_policy.rb
+++ b/app/policies/ipv6address_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for Ipv6Address
 class Ipv6AddressPolicy < ApplicationPolicy

--- a/app/policies/mailaccount_policy.rb
+++ b/app/policies/mailaccount_policy.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength, Metrics/MethodLength
-# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-require File.expand_path '../application_policy.rb', __FILE__
+# rubocop:disable Metrics/ClassLength
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for MailAccount
 class MailAccountPolicy < ApplicationPolicy
@@ -82,7 +81,8 @@ class MailAccountPolicy < ApplicationPolicy
 
   private
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
   # @return [Boolean]
   def quotacheck(*requested_quota, update: false)
     unless requested_quota.blank?
@@ -100,6 +100,8 @@ class MailAccountPolicy < ApplicationPolicy
     end
     false
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
 
   # @return [Fixnum]
   def check_account_num
@@ -124,6 +126,8 @@ class MailAccountPolicy < ApplicationPolicy
   end
 
   # @retun [Boolean]
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
   def check_update_params(params)
     if params.key?(:id)
       return false unless check_id(params[:id])
@@ -144,6 +148,8 @@ class MailAccountPolicy < ApplicationPolicy
     end
     true
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
 
   def check_id(id)
     return true if id == record.id
@@ -208,3 +214,4 @@ class MailAccountPolicy < ApplicationPolicy
     [].to_Set
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/policies/mailalias_policy.rb
+++ b/app/policies/mailalias_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for MailAlias
 class MailAliasPolicy < ApplicationPolicy

--- a/app/policies/mailforwarding_policy.rb
+++ b/app/policies/mailforwarding_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for MailForwarding
 class MailForwardingPolicy < ApplicationPolicy

--- a/app/policies/mailsource_policy.rb
+++ b/app/policies/mailsource_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for MailSource
 class MailSourcePolicy < ApplicationPolicy

--- a/app/policies/package_policy.rb
+++ b/app/policies/package_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for Package
 class PackagePolicy < ApplicationPolicy
@@ -23,6 +23,7 @@ class PackagePolicy < ApplicationPolicy
     return true if user.packages.map(&:id).include?(record.id)
     false
   end
+  # rubocop:enable Metrics/AbcSize
 
   # Checks if current user is allowed to update the record
   #
@@ -110,6 +111,7 @@ class PackagePolicy < ApplicationPolicy
   end
 
   # check amount of all assigned customers to a package before permission
+  # rubocop:disable Metrics/AbcSize
   def check_update_params(params)
     return false unless user.reseller?
     params.each_pair do |k, v|
@@ -120,6 +122,7 @@ class PackagePolicy < ApplicationPolicy
     end
     true
   end
+  # rubocop:enable Metrics/AbcSize
 
   def check_quota_prop(key)
     # call helper methods from quota_helper.rb

--- a/app/policies/phpruntime_policy.rb
+++ b/app/policies/phpruntime_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for PhpRuntime
 class PhpRuntimePolicy < ApplicationPolicy

--- a/app/policies/sftpuser_policy.rb
+++ b/app/policies/sftpuser_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for SftpUser
 class SftpUserPolicy < ApplicationPolicy

--- a/app/policies/shell_policy.rb
+++ b/app/policies/shell_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for Shell
 class ShellPolicy < ApplicationPolicy

--- a/app/policies/shelluser_policy.rb
+++ b/app/policies/shelluser_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for ShellUser
 class ShellUserPolicy < ApplicationPolicy

--- a/app/policies/sshpubkey_policy.rb
+++ b/app/policies/sshpubkey_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for SshPubkey
 class SshPubkeyPolicy < ApplicationPolicy

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/ClassLength
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for User
 class UserPolicy < ApplicationPolicy
@@ -183,3 +183,4 @@ class UserPolicy < ApplicationPolicy
     false
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/policies/vhost_policy.rb
+++ b/app/policies/vhost_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../application_policy.rb', __FILE__
+require File.expand_path('application_policy.rb', __dir__)
 
 # Policy for Vhost
 class VhostPolicy < ApplicationPolicy

--- a/config/puma.example.rb
+++ b/config/puma.example.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 environment 'production'
 
 pidfile 'puma.pid'

--- a/database/seeds.rb
+++ b/database/seeds.rb
@@ -271,3 +271,4 @@ when 'MYSQL'
 else
   raise 'Error: unsupported database adapter!'
 end
+# rubocop:enable Metrics/LineLength

--- a/init.rb
+++ b/init.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
+
 require 'yaml'
 
-lp = File.expand_path('../', __FILE__)
+lp = File.expand_path(__dir__)
 
 @environment = ENV['RACK_ENV'] || 'development'
+# rubocop:disable Security/YAMLLoad
 @dbconfig = YAML.load(File.read("#{lp}/config/database.yml"))[@environment]
+# rubocop:enable Security/YAMLLoad
 
 require 'bundler/setup'
 

--- a/init.rb
+++ b/init.rb
@@ -32,6 +32,33 @@ end
 require 'bcrypt'
 require 'sshkey'
 
+# monkey patch to fix deprecation warning
+# rubocop:disable Style/Documentation, Style/RaiseArgs, Metrics/LineLength
+# rubocop:disable Style/CaseEquality
+module DataObjects
+  module Pooling
+    class Pool
+      attr_reader :available
+      attr_reader :used
+
+      def initialize(max_size, resource, args)
+        raise ArgumentError.new("+max_size+ should be an Integer but was #{max_size.inspect}") unless Integer === max_size
+        raise ArgumentError.new("+resource+ should be a Class but was #{resource.inspect}") unless Class === resource
+
+        @max_size = max_size
+        @resource = resource
+        @args = args
+
+        @available = []
+        @used      = {}
+        DataObjects::Pooling.append_pool(self)
+      end
+    end
+  end
+end
+# rubocop:enable Style/Documentation, Style/RaiseArgs, Metrics/LineLength
+# rubocop:enable Style/CaseEquality
+
 # load models and stuff
 require_relative 'app/models/group'
 require_relative 'app/models/user'

--- a/spec/controllers/apikey_controller_spec.rb
+++ b/spec/controllers/apikey_controller_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/EmptyLineAfterFinalLet
+# rubocop:disable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet
 describe 'VHost-API Apikey Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
-      context 'by an admin user' do
+      context 'when by an admin user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testapikey) { create(:apikey) }
@@ -111,7 +115,7 @@ describe 'VHost-API Apikey Controller' do
         end
 
         describe 'POST' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             let(:apikey_attrs) { attributes_for(:apikey) }
 
             it 'authorizes the request by using the policies' do
@@ -176,8 +180,8 @@ describe 'VHost-API Apikey Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , name: \'foo, enabled: true }' }
 
               it 'does not create a new apikey' do
@@ -238,7 +242,7 @@ describe 'VHost-API Apikey Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_apikey_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not create a new apikey' do
@@ -299,7 +303,7 @@ describe 'VHost-API Apikey Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_apikey) }
 
               it 'does not create a new apikey' do
@@ -369,7 +373,7 @@ describe 'VHost-API Apikey Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(Pundit.authorize(testadmin, Apikey, :create?)).to be_truthy
             end
@@ -423,8 +427,8 @@ describe 'VHost-API Apikey Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{, comment:\'foo, enabled: true }' }
 
               it 'does not update the apikey' do
@@ -486,7 +490,7 @@ describe 'VHost-API Apikey Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_apikey_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not update the apikey' do
@@ -548,7 +552,7 @@ describe 'VHost-API Apikey Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_apikey) }
 
               it 'does not update the apikey' do
@@ -617,7 +621,7 @@ describe 'VHost-API Apikey Controller' do
             end
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             # it 'returns an API Error' do
             #   invincibleapikey = create(:apikey)
             #   allow(Apikey).to receive(
@@ -676,7 +680,7 @@ describe 'VHost-API Apikey Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invincibleapikey = create(:apikey)
               allow(Apikey).to receive(
@@ -708,7 +712,7 @@ describe 'VHost-API Apikey Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:usergroup) { create(:group) }
@@ -801,7 +805,7 @@ describe 'VHost-API Apikey Controller' do
         end
 
         describe 'POST' do
-          context 'with exhausted quota' do
+          context 'when with exhausted quota' do
             let(:testuser) { create(:user_with_exhausted_apikey_quota) }
             it 'does not authorize the request' do
               expect do
@@ -849,7 +853,7 @@ describe 'VHost-API Apikey Controller' do
             end
           end
 
-          context 'with available quota' do
+          context 'when with available quota' do
             let!(:testuser) { create(:user_with_apikeys) }
             let!(:newapikey) do
               attributes_for(:apikey, user_id: testuser.id)
@@ -907,7 +911,7 @@ describe 'VHost-API Apikey Controller' do
             end
           end
 
-          context 'with using different user_id in attributes' do
+          context 'when with using different user_id in attributes' do
             let(:testuser) { create(:user_with_apikeys) }
             let(:anotheruser) { create(:user) }
             let(:unauthorized_attrs) do
@@ -1053,7 +1057,7 @@ describe 'VHost-API Apikey Controller' do
         end
       end
 
-      context 'by an unauthenticated user' do
+      context 'when by an unauthenticated user' do
         let!(:testapikey) { create(:apikey) }
 
         before(:each) do
@@ -1147,3 +1151,7 @@ describe 'VHost-API Apikey Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/EmptyLineAfterFinalLet
+# rubocop:enable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet

--- a/spec/controllers/compression_spec.rb
+++ b/spec/controllers/compression_spec.rb
@@ -24,7 +24,8 @@ describe 'VHost-API Compression gzip/deflate' do
 
       context 'when client supports compression' do
         it 'responds with compressed data' do
-          %w[deflate gzip deflate,gzip gzip,deflate].each do |method|
+          # Rack::Deflate removed support for deflate, so it's just gzip for now
+          %w[gzip].each do |method|
             req_headers = auth_headers_apikey(testadmin.id)
             req_headers['HTTP_ACCEPT_ENCODING'] = method
             get(

--- a/spec/controllers/compression_spec.rb
+++ b/spec/controllers/compression_spec.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe 'VHost-API Compression gzip/deflate' do
+  # rubocop:disable Security/YAMLLoad
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
+
+  # rubocop:enable Security/YAMLLoad
 
   api_versions = %w[1]
 
@@ -18,7 +22,7 @@ describe 'VHost-API Compression gzip/deflate' do
       let(:user3) { create(:user) }
       let(:user4) { create(:user) }
 
-      context 'client supports compression' do
+      context 'when client supports compression' do
         it 'responds with compressed data' do
           %w[deflate gzip deflate,gzip gzip,deflate].each do |method|
             req_headers = auth_headers_apikey(testadmin.id)
@@ -35,7 +39,7 @@ describe 'VHost-API Compression gzip/deflate' do
         end
       end
 
-      context 'client does not support compression' do
+      context 'when client does not support compression' do
         it 'responds with uncompressed data' do
           get(
             "/api/v#{api_version}/users", nil,
@@ -47,3 +51,4 @@ describe 'VHost-API Compression gzip/deflate' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/controllers/dkim_controller_spec.rb
+++ b/spec/controllers/dkim_controller_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/EmptyExampleGroup
+# rubocop:disable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet
 describe 'VHost-API Dkim Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
-      context 'by an admin user' do
+      context 'when by an admin user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testdkim) { create(:dkim) }
@@ -130,7 +134,7 @@ describe 'VHost-API Dkim Controller' do
                            domain_id: domain.id)
           end
 
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, Dkim, :create?)
@@ -192,8 +196,8 @@ describe 'VHost-API Dkim Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{, selector: \'foo, enabled:true}' }
 
               it 'does not create a new dkim' do
@@ -252,7 +256,7 @@ describe 'VHost-API Dkim Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_dkim_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not create a new dkim' do
@@ -310,7 +314,7 @@ describe 'VHost-API Dkim Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_dkim) }
 
               it 'does not create a new dkim' do
@@ -377,7 +381,7 @@ describe 'VHost-API Dkim Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, Dkim, :create?)
@@ -441,8 +445,8 @@ describe 'VHost-API Dkim Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{, selector: \'foo, enabled:true}' }
 
               it 'does not update the dkim' do
@@ -506,7 +510,7 @@ describe 'VHost-API Dkim Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_dkim_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not update the dkim' do
@@ -569,7 +573,7 @@ describe 'VHost-API Dkim Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_dkim) }
 
               it 'does not update the dkim' do
@@ -639,7 +643,7 @@ describe 'VHost-API Dkim Controller' do
             end
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             let(:domain) { create(:domain, name: 'invincible.de') }
 
             # it 'returns an API Error' do
@@ -706,7 +710,7 @@ describe 'VHost-API Dkim Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invincible = create(:dkim,
                                   selector: 'invincible')
@@ -739,7 +743,7 @@ describe 'VHost-API Dkim Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:usergroup) { create(:group) }
@@ -891,7 +895,7 @@ describe 'VHost-API Dkim Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'with using different user_id in attributes' do
+          context 'when with using different user_id in attributes' do
             let(:testuser) { create(:user_with_dkims) }
             let(:anotheruser) { create(:user_with_domains) }
 
@@ -1035,7 +1039,7 @@ describe 'VHost-API Dkim Controller' do
         end
       end
 
-      context 'by an unauthenticated user' do
+      context 'when by an unauthenticated user' do
         let!(:testdkim) { create(:dkim) }
 
         before(:each) do
@@ -1129,3 +1133,7 @@ describe 'VHost-API Dkim Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/EmptyExampleGroup
+# rubocop:enable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet

--- a/spec/controllers/dkim_signing_controller_spec.rb
+++ b/spec/controllers/dkim_signing_controller_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/EmptyExampleGroup
+# rubocop:disable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet
 describe 'VHost-API DkimSigning Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
-      context 'by an admin user' do
+      context 'when by an admin user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testdkimsigning) { create(:dkimsigning) }
@@ -102,7 +106,7 @@ describe 'VHost-API DkimSigning Controller' do
                            dkim_id: dkim.id)
           end
 
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, DkimSigning, :create?)
@@ -164,8 +168,8 @@ describe 'VHost-API DkimSigning Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{, author: \'foo, enabled:true}' }
 
               it 'does not create a new dkimsigning' do
@@ -224,7 +228,7 @@ describe 'VHost-API DkimSigning Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_dkimsigning_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not create a new dkimsigning' do
@@ -283,7 +287,7 @@ describe 'VHost-API DkimSigning Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_dkimsigning) }
 
               it 'does not create a new dkimsigning' do
@@ -350,7 +354,7 @@ describe 'VHost-API DkimSigning Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, DkimSigning, :create?)
@@ -414,8 +418,8 @@ describe 'VHost-API DkimSigning Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{, author: \'foo, enabled:true}' }
 
               it 'does not update the dkimsigning' do
@@ -480,7 +484,7 @@ describe 'VHost-API DkimSigning Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_dkimsigning_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not update the dkimsigning' do
@@ -545,7 +549,7 @@ describe 'VHost-API DkimSigning Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_dkimsigning) }
 
               it 'does not update the dkimsigning' do
@@ -615,7 +619,7 @@ describe 'VHost-API DkimSigning Controller' do
             end
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             let(:domain) { create(:domain, name: 'invincible.de') }
             let(:dkim) { create(:dkim, domain_id: domain.id) }
 
@@ -681,7 +685,7 @@ describe 'VHost-API DkimSigning Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invincible = create(:dkimsigning,
                                   author: 'foo@invincible.org')
@@ -714,7 +718,7 @@ describe 'VHost-API DkimSigning Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:usergroup) { create(:group) }
@@ -866,7 +870,7 @@ describe 'VHost-API DkimSigning Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'with using different dkim_id in attributes' do
+          context 'when with using different dkim_id in attributes' do
             let(:testuser) { create(:user_with_dkimsignings) }
             let(:anotheruser) { create(:user_with_dkims) }
 
@@ -1016,7 +1020,7 @@ describe 'VHost-API DkimSigning Controller' do
         end
       end
 
-      context 'by an unauthenticated user' do
+      context 'when by an unauthenticated user' do
         let!(:testdkimsigning) { create(:dkimsigning) }
 
         before(:each) do
@@ -1110,3 +1114,7 @@ describe 'VHost-API DkimSigning Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/EmptyExampleGroup
+# rubocop:enable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet

--- a/spec/controllers/domain_controller_spec.rb
+++ b/spec/controllers/domain_controller_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/EmptyLineAfterFinalLet
+# rubocop:disable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet
 describe 'VHost-API Domain Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
-      context 'by an admin user' do
+      context 'when by an admin user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testdomain) { create(:domain) }
@@ -87,7 +91,7 @@ describe 'VHost-API Domain Controller' do
         end
 
         describe 'POST' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(Pundit.authorize(testadmin, Domain, :create?)).to be_truthy
             end
@@ -147,8 +151,8 @@ describe 'VHost-API Domain Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , name: \'foo, enabled: true }' }
 
               it 'does not create a new domain' do
@@ -207,7 +211,7 @@ describe 'VHost-API Domain Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_domain_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not create a new domain' do
@@ -265,7 +269,7 @@ describe 'VHost-API Domain Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_domain) }
 
               it 'does not create a new domain' do
@@ -329,7 +333,7 @@ describe 'VHost-API Domain Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               before(:each) do
                 create(:domain, name: 'existing.domain')
               end
@@ -378,7 +382,7 @@ describe 'VHost-API Domain Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(Pundit.authorize(testadmin, Domain, :create?)).to be_truthy
             end
@@ -430,8 +434,8 @@ describe 'VHost-API Domain Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , name: \'foo, enabled: true }' }
 
               it 'does not update the domain' do
@@ -491,7 +495,7 @@ describe 'VHost-API Domain Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_domain_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not update the domain' do
@@ -550,7 +554,7 @@ describe 'VHost-API Domain Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_domain) }
 
               it 'does not update the domain' do
@@ -615,7 +619,7 @@ describe 'VHost-API Domain Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:resource_conflict) do
                 attributes_for(:domain,
                                name: 'existing.domain')
@@ -671,7 +675,7 @@ describe 'VHost-API Domain Controller' do
             end
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             # it 'returns an API Error' do
             #   invincibledomain = create(:domain, name: 'invincible.org')
             #   allow(Domain).to receive(
@@ -730,7 +734,7 @@ describe 'VHost-API Domain Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invincibledomain = create(:domain, name: 'invincible.org')
               allow(Domain).to receive(
@@ -762,7 +766,7 @@ describe 'VHost-API Domain Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:usergroup) { create(:group) }
@@ -855,7 +859,7 @@ describe 'VHost-API Domain Controller' do
         end
 
         describe 'POST' do
-          context 'with exhausted quota' do
+          context 'when with exhausted quota' do
             let(:testuser) { create(:user_with_exhausted_domain_quota) }
             it 'does not authorize the request' do
               expect do
@@ -901,7 +905,7 @@ describe 'VHost-API Domain Controller' do
             end
           end
 
-          context 'with available quota' do
+          context 'when with available quota' do
             let!(:testuser) { create(:user_with_domains) }
             let!(:newdomain) do
               attributes_for(:domain, name: 'new.org', user_id: testuser.id)
@@ -956,7 +960,7 @@ describe 'VHost-API Domain Controller' do
             end
           end
 
-          context 'with using different user_id in attributes' do
+          context 'when with using different user_id in attributes' do
             let(:testuser) { create(:user_with_domains) }
             let(:anotheruser) { create(:user) }
 
@@ -1100,7 +1104,7 @@ describe 'VHost-API Domain Controller' do
         end
       end
 
-      context 'by an unauthenticated user' do
+      context 'when by an unauthenticated user' do
         let!(:testdomain) { create(:domain) }
 
         before(:each) do
@@ -1194,3 +1198,7 @@ describe 'VHost-API Domain Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/EmptyLineAfterFinalLet
+# rubocop:enable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet

--- a/spec/controllers/group_controller_spec.rb
+++ b/spec/controllers/group_controller_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/EmptyLineAfterFinalLet
+# rubocop:disable RSpec/HookArgument
 describe 'VHost-API Group Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
-      context 'by an authenticated and authorized user' do
+      context 'when by an authenticated and authorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testgroup) { create(:group) }
@@ -83,7 +87,7 @@ describe 'VHost-API Group Controller' do
         end
 
         describe 'POST' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(Pundit.authorize(testadmin, Group, :create?)).to be_truthy
             end
@@ -143,8 +147,8 @@ describe 'VHost-API Group Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , name: \'foo, enabled: true }' }
 
               it 'does not create a new group' do
@@ -203,7 +207,7 @@ describe 'VHost-API Group Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_group_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not create a new group' do
@@ -261,7 +265,7 @@ describe 'VHost-API Group Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_group) }
 
               it 'does not create a new group' do
@@ -329,7 +333,7 @@ describe 'VHost-API Group Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:resource_conflict) { attributes_for(:group) }
 
               it 'does not create a new group' do
@@ -373,7 +377,7 @@ describe 'VHost-API Group Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(Pundit.authorize(testadmin, Group, :create?)).to be_truthy
             end
@@ -425,8 +429,8 @@ describe 'VHost-API Group Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , name: \'foo, enabled: true }' }
 
               it 'does not update the group' do
@@ -486,7 +490,7 @@ describe 'VHost-API Group Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_group_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not update the group' do
@@ -545,7 +549,7 @@ describe 'VHost-API Group Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_group) }
 
               it 'does not update the group' do
@@ -614,7 +618,7 @@ describe 'VHost-API Group Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:resource_conflict) { attributes_for(:group, name: 'admin') }
 
               it 'does not update the group' do
@@ -656,7 +660,7 @@ describe 'VHost-API Group Controller' do
             end
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             # it 'returns an API Error' do
             #   invinciblegroup = create(:group, name: 'invincible')
             #   allow(Group).to receive(
@@ -726,7 +730,7 @@ describe 'VHost-API Group Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invinciblegroup = create(:group, name: 'invincible')
               allow(Group).to receive(
@@ -766,7 +770,7 @@ describe 'VHost-API Group Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testgroup) { create(:group) }
@@ -990,7 +994,7 @@ describe 'VHost-API Group Controller' do
         end
       end
 
-      context 'by an unauthenticated user' do
+      context 'when by an unauthenticated user' do
         before(:each) do
           create(:group, name: 'admin')
           create(:group, name: 'reseller')
@@ -1082,3 +1086,7 @@ describe 'VHost-API Group Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/EmptyLineAfterFinalLet
+# rubocop:enable RSpec/HookArgument

--- a/spec/controllers/mail_account_controller_spec.rb
+++ b/spec/controllers/mail_account_controller_spec.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 require 'fileutils'
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/EmptyExampleGroup, RSpec/EmptyLineAfterFinalLet
+# rubocop:disable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet
 describe 'VHost-API MailAccount Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
-      context 'by an admin user' do
+      context 'when by an admin user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testmailaccount) { create(:mailaccount) }
@@ -137,7 +141,7 @@ describe 'VHost-API MailAccount Controller' do
                            domain_id: domain.id)
           end
 
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, MailAccount, :create?)
@@ -199,8 +203,8 @@ describe 'VHost-API MailAccount Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , email: \'foo, enabled: true }' }
 
               it 'does not create a new mailaccount' do
@@ -259,7 +263,7 @@ describe 'VHost-API MailAccount Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_mailaccount_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not create a new mailaccount' do
@@ -318,7 +322,7 @@ describe 'VHost-API MailAccount Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_mailaccount) }
 
               it 'does not create a new mailaccount' do
@@ -382,7 +386,7 @@ describe 'VHost-API MailAccount Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:domain) { create(:domain, name: 'mailaccount.org') }
 
               before(:each) do
@@ -440,7 +444,7 @@ describe 'VHost-API MailAccount Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, MailAccount, :create?)
@@ -504,8 +508,8 @@ describe 'VHost-API MailAccount Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , email: \'foo, enabled: true }' }
 
               it 'does not update the mailaccount' do
@@ -570,7 +574,7 @@ describe 'VHost-API MailAccount Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_mailaccount_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not update the mailaccount' do
@@ -635,7 +639,7 @@ describe 'VHost-API MailAccount Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_mailaccount) }
 
               it 'does not update the mailaccount' do
@@ -705,7 +709,7 @@ describe 'VHost-API MailAccount Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:domain) { create(:domain, name: 'mailaccount.org') }
               let(:resource_conflict) do
                 attributes_for(:mailaccount,
@@ -767,7 +771,7 @@ describe 'VHost-API MailAccount Controller' do
             end
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             let(:domain) { create(:domain, name: 'invincible.de') }
 
             it 'returns an API Error' do
@@ -832,7 +836,7 @@ describe 'VHost-API MailAccount Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invincible = create(:mailaccount,
                                   email: 'foo@invincible.org')
@@ -865,7 +869,7 @@ describe 'VHost-API MailAccount Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:usergroup) { create(:group) }
@@ -960,7 +964,7 @@ describe 'VHost-API MailAccount Controller' do
         end
 
         describe 'POST' do
-          context 'with exhausted quota' do
+          context 'when with exhausted quota' do
             let(:testuser) { create(:user_with_exhausted_mailaccount_quota) }
             it 'does not authorize the request' do
               expect do
@@ -1006,7 +1010,7 @@ describe 'VHost-API MailAccount Controller' do
             end
           end
 
-          context 'with available quota' do
+          context 'when with available quota' do
             let(:testuser) { create(:user_with_mailaccounts) }
             let(:domain) { testuser.domains.first }
             let(:new) do
@@ -1065,7 +1069,7 @@ describe 'VHost-API MailAccount Controller' do
             end
           end
 
-          context 'with using different user_id in attributes' do
+          context 'when with using different user_id in attributes' do
             let(:testuser) { create(:user_with_mailaccounts) }
             let(:anotheruser) { create(:user_with_domains) }
 
@@ -1209,7 +1213,7 @@ describe 'VHost-API MailAccount Controller' do
         end
       end
 
-      context 'by an unauthenticated user' do
+      context 'when by an unauthenticated user' do
         let!(:testmailaccount) { create(:mailaccount) }
 
         before(:each) do
@@ -1303,3 +1307,7 @@ describe 'VHost-API MailAccount Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/EmptyExampleGroup, RSpec/EmptyLineAfterFinalLet
+# rubocop:enable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet

--- a/spec/controllers/mail_alias_controller_spec.rb
+++ b/spec/controllers/mail_alias_controller_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/PredicateMatcher, RSpec/ScatteredLet
 describe 'VHost-API MailAlias Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
@@ -9,7 +12,7 @@ describe 'VHost-API MailAlias Controller' do
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
-      context 'by an admin' do
+      context 'when by an admin' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testmailalias) { create(:mailalias) }
@@ -105,7 +108,7 @@ describe 'VHost-API MailAlias Controller' do
                            dest: [mailaccount.id])
           end
 
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, MailAlias, :create?)
@@ -167,8 +170,8 @@ describe 'VHost-API MailAlias Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , address: \'foo, enabled:true}' }
 
               it 'does not create a new mailalias' do
@@ -227,7 +230,7 @@ describe 'VHost-API MailAlias Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_mailalias_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not create a new mailalias' do
@@ -286,7 +289,7 @@ describe 'VHost-API MailAlias Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_mailalias) }
 
               it 'does not create a new mailalias' do
@@ -351,7 +354,7 @@ describe 'VHost-API MailAlias Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:domain) { create(:domain, name: 'mailalias.org') }
               let(:mailaccount) do
                 create(:mailaccount,
@@ -412,7 +415,7 @@ describe 'VHost-API MailAlias Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             let(:domain) { testmailalias.domain }
             let(:mailaccount) do
               create(:mailaccount,
@@ -486,8 +489,8 @@ describe 'VHost-API MailAlias Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , address: \'foo, enabled:true}' }
 
               it 'does not update the mailalias' do
@@ -552,7 +555,7 @@ describe 'VHost-API MailAlias Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_mailalias_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not update the mailalias' do
@@ -617,7 +620,7 @@ describe 'VHost-API MailAlias Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_mailalias) }
 
               it 'does not update the mailalias' do
@@ -688,7 +691,7 @@ describe 'VHost-API MailAlias Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:domain) { create(:domain, name: 'mailalias.org') }
               let(:resource_conflict) do
                 attributes_for(:mailalias,
@@ -750,7 +753,7 @@ describe 'VHost-API MailAlias Controller' do
             end
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             let(:domain) { create(:domain, name: 'invincible.de') }
 
             it 'returns an API Error' do
@@ -815,7 +818,7 @@ describe 'VHost-API MailAlias Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invincible = create(:mailalias,
                                   address: 'foo@invincible.org')
@@ -848,7 +851,7 @@ describe 'VHost-API MailAlias Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:usergroup) { create(:group) }
@@ -943,7 +946,7 @@ describe 'VHost-API MailAlias Controller' do
         end
 
         describe 'POST' do
-          context 'with exhausted quota' do
+          context 'when with exhausted quota' do
             let(:testuser) { create(:user_with_exhausted_mailalias_quota) }
 
             it 'does not authorize the request' do
@@ -990,7 +993,7 @@ describe 'VHost-API MailAlias Controller' do
             end
           end
 
-          context 'with available quota' do
+          context 'when with available quota' do
             let(:testuser) { create(:user_with_mailaliases) }
             let(:domain) { testuser.domains.first }
             let(:mailaccount) { domain.mail_accounts.first }
@@ -1051,7 +1054,7 @@ describe 'VHost-API MailAlias Controller' do
             end
           end
 
-          context 'with using different user_id in attributes' do
+          context 'when with using different user_id in attributes' do
             let(:testuser) { create(:user_with_mailaliases) }
             let(:anotheruser) { create(:user_with_mailaccounts) }
             let(:new_attrs) do
@@ -1198,7 +1201,7 @@ describe 'VHost-API MailAlias Controller' do
         end
       end
 
-      context 'by an unauthenticated user' do
+      context 'when by an unauthenticated user' do
         let!(:testmailalias) { create(:mailalias) }
 
         before do
@@ -1292,3 +1295,6 @@ describe 'VHost-API MailAlias Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/PredicateMatcher, RSpec/ScatteredLet

--- a/spec/controllers/mail_forwarding_controller_spec.rb
+++ b/spec/controllers/mail_forwarding_controller_spec.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/EmptyLineAfterFinalLet
+# rubocop:disable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet
 describe 'VHost-API MailForwarding Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
       let(:baseurl) { "/api/v#{api_version}" }
-      context 'by an admin' do
+      context 'when by an admin' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testmailforwarding) { create(:mailforwarding) }
@@ -106,7 +110,7 @@ describe 'VHost-API MailForwarding Controller' do
                            domain_id: domain.id)
           end
 
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, MailForwarding, :create?)
@@ -168,8 +172,8 @@ describe 'VHost-API MailForwarding Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , address: \'foo, enabled:true}' }
 
               it 'does not create a new mailforwarding' do
@@ -228,7 +232,7 @@ describe 'VHost-API MailForwarding Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_mailforwarding_attrs) do
                 { foo: 'bar', disabled: 1234 }
               end
@@ -289,7 +293,7 @@ describe 'VHost-API MailForwarding Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_mailforwarding) }
 
               it 'does not create a new mailforwarding' do
@@ -357,7 +361,7 @@ describe 'VHost-API MailForwarding Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:domain) { create(:domain, name: 'mailforwarding.org') }
               let(:mailaccount) do
                 create(:mailaccount,
@@ -417,7 +421,7 @@ describe 'VHost-API MailForwarding Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             let(:domain) { testmailforwarding.domain }
             let(:mailaccount) do
               create(:mailaccount,
@@ -491,8 +495,8 @@ describe 'VHost-API MailForwarding Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , address: \'foo, enabled:true}' }
 
               it 'does not update the mailforwarding' do
@@ -556,7 +560,7 @@ describe 'VHost-API MailForwarding Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_mailforwarding_attrs) do
                 { foo: 'bar', disabled: 1234 }
               end
@@ -622,7 +626,7 @@ describe 'VHost-API MailForwarding Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_mailforwarding) }
 
               it 'does not update the mailforwarding' do
@@ -696,7 +700,7 @@ describe 'VHost-API MailForwarding Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:domain) { create(:domain, name: 'mailforwarding.org') }
               let(:resource_conflict) do
                 attributes_for(:mailforwarding,
@@ -758,7 +762,7 @@ describe 'VHost-API MailForwarding Controller' do
             end
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             let(:domain) { create(:domain, name: 'invincible.de') }
 
             it 'returns an API Error' do
@@ -824,7 +828,7 @@ describe 'VHost-API MailForwarding Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invincible = create(:mailforwarding,
                                   address: 'foo@invincible.org')
@@ -857,7 +861,7 @@ describe 'VHost-API MailForwarding Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:usergroup) { create(:group) }
@@ -952,7 +956,7 @@ describe 'VHost-API MailForwarding Controller' do
         end
 
         describe 'POST' do
-          context 'with exhausted quota' do
+          context 'when with exhausted quota' do
             let(:testuser) { create(:user_with_exhausted_mailforwarding_quota) }
             it 'does not authorize the request' do
               expect do
@@ -998,7 +1002,7 @@ describe 'VHost-API MailForwarding Controller' do
             end
           end
 
-          context 'with available quota' do
+          context 'when with available quota' do
             let(:testuser) { create(:user_with_mailforwardings) }
             let(:domain) { testuser.domains.first }
             let(:new) do
@@ -1057,7 +1061,7 @@ describe 'VHost-API MailForwarding Controller' do
             end
           end
 
-          context 'with using different user_id in attributes' do
+          context 'when with using different user_id in attributes' do
             let(:testuser) { create(:user_with_mailforwardings) }
             let(:anotheruser) { create(:user_with_mailaccounts) }
             let(:new_attrs) do
@@ -1208,7 +1212,7 @@ describe 'VHost-API MailForwarding Controller' do
         end
       end
 
-      context 'by an unauthenticated user' do
+      context 'when by an unauthenticated user' do
         let!(:testmailforwarding) { create(:mailforwarding) }
 
         before(:each) do
@@ -1305,3 +1309,7 @@ describe 'VHost-API MailForwarding Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/EmptyLineAfterFinalLet
+# rubocop:enable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet

--- a/spec/controllers/mail_source_controller_spec.rb
+++ b/spec/controllers/mail_source_controller_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/EmptyLineAfterFinalLet
+# rubocop:disable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet
 describe 'VHost-API MailSource Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
-      context 'by an admin' do
+      context 'when by an admin' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testmailsource) { create(:mailsource) }
@@ -105,7 +109,7 @@ describe 'VHost-API MailSource Controller' do
                            src: [mailaccount.id])
           end
 
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, MailSource, :create?)
@@ -167,8 +171,8 @@ describe 'VHost-API MailSource Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , address: \'foo, enabled:true}' }
 
               it 'does not create a new mailsource' do
@@ -227,7 +231,7 @@ describe 'VHost-API MailSource Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_mailsource_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not create a new mailsource' do
@@ -286,7 +290,7 @@ describe 'VHost-API MailSource Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_mailsource) }
 
               it 'does not create a new mailsource' do
@@ -350,7 +354,7 @@ describe 'VHost-API MailSource Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:domain) { create(:domain, name: 'mailsource.org') }
               let(:mailaccount) do
                 create(:mailaccount,
@@ -411,7 +415,7 @@ describe 'VHost-API MailSource Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             let(:domain) { testmailsource.domain }
             let(:mailaccount) do
               create(:mailaccount,
@@ -485,8 +489,8 @@ describe 'VHost-API MailSource Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , address: \'foo, enabled:true}' }
 
               it 'does not update the mailsource' do
@@ -551,7 +555,7 @@ describe 'VHost-API MailSource Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_mailsource_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not update the mailsource' do
@@ -616,7 +620,7 @@ describe 'VHost-API MailSource Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_mailsource) }
 
               it 'does not update the mailsource' do
@@ -686,7 +690,7 @@ describe 'VHost-API MailSource Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:domain) { create(:domain, name: 'mailsource.org') }
               let(:resource_conflict) do
                 attributes_for(:mailsource,
@@ -748,7 +752,7 @@ describe 'VHost-API MailSource Controller' do
             end
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             let(:domain) { create(:domain, name: 'invincible.de') }
 
             it 'returns an API Error' do
@@ -813,7 +817,7 @@ describe 'VHost-API MailSource Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invincible = create(:mailsource,
                                   address: 'foo@invincible.org')
@@ -846,7 +850,7 @@ describe 'VHost-API MailSource Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:usergroup) { create(:group) }
@@ -941,7 +945,7 @@ describe 'VHost-API MailSource Controller' do
         end
 
         describe 'POST' do
-          context 'with exhausted quota' do
+          context 'when with exhausted quota' do
             let(:testuser) { create(:user_with_exhausted_mailsource_quota) }
             it 'does not authorize the request' do
               expect do
@@ -987,7 +991,7 @@ describe 'VHost-API MailSource Controller' do
             end
           end
 
-          context 'with available quota' do
+          context 'when with available quota' do
             let(:testuser) { create(:user_with_mailsources) }
             let(:domain) { testuser.domains.first }
             let(:mailaccount) { domain.mail_accounts.first }
@@ -1048,7 +1052,7 @@ describe 'VHost-API MailSource Controller' do
             end
           end
 
-          context 'with using different user_id in attributes' do
+          context 'when with using different user_id in attributes' do
             let(:testuser) { create(:user_with_mailsources) }
             let(:anotheruser) { create(:user_with_mailaccounts) }
             let(:domain) { anotheruser.domains.first }
@@ -1196,7 +1200,7 @@ describe 'VHost-API MailSource Controller' do
         end
       end
 
-      context 'by an unauthenticated user' do
+      context 'when by an unauthenticated user' do
         let!(:testmailsource) { create(:mailsource) }
 
         before(:each) do
@@ -1290,3 +1294,7 @@ describe 'VHost-API MailSource Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/EmptyLineAfterFinalLet
+# rubocop:enable RSpec/PredicateMatcher, RSpec/HookArgument, RSpec/ScatteredLet

--- a/spec/controllers/package_controller_spec.rb
+++ b/spec/controllers/package_controller_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/EmptyLineAfterFinalLet
+# rubocop:disable RSpec/HookArgument
 describe 'VHost-API Package Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
-      context 'by an admin user' do
+      context 'when by an admin user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:usergroup) { create(:group, name: 'user') }
@@ -89,7 +93,7 @@ describe 'VHost-API Package Controller' do
         end
 
         describe 'POST' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, Package, :create?)
@@ -151,8 +155,8 @@ describe 'VHost-API Package Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , name: \'foo, enabled: true }' }
 
               it 'does not create a new package' do
@@ -211,7 +215,7 @@ describe 'VHost-API Package Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_package_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not create a new package' do
@@ -269,7 +273,7 @@ describe 'VHost-API Package Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_package) }
 
               it 'does not create a new package' do
@@ -340,7 +344,7 @@ describe 'VHost-API Package Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             it 'authorizes the request by using the policies' do
               expect(
                 Pundit.authorize(testadmin, Package, :create?)
@@ -396,8 +400,8 @@ describe 'VHost-API Package Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , name: \'foo, enabled: true }' }
 
               it 'does not update the package' do
@@ -457,7 +461,7 @@ describe 'VHost-API Package Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_package_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not update the package' do
@@ -516,7 +520,7 @@ describe 'VHost-API Package Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_package) }
 
               it 'does not update the package' do
@@ -612,7 +616,7 @@ describe 'VHost-API Package Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invinciblepackage = create(:package, name: 'invincible')
               allow(Package).to receive(
@@ -652,7 +656,7 @@ describe 'VHost-API Package Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:usergroup) { create(:group, name: 'user') }
@@ -893,7 +897,7 @@ describe 'VHost-API Package Controller' do
         end
       end
 
-      context 'by an unauthenticated (thus authentication_failed) user' do
+      context 'when by an unauthenticated (thus authentication_failed) user' do
         before(:each) do
           create(:user, name: 'admin')
           create(:user, name: 'reseller')
@@ -985,3 +989,7 @@ describe 'VHost-API Package Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/EmptyLineAfterFinalLet
+# rubocop:enable RSpec/HookArgument

--- a/spec/controllers/url_query_spec.rb
+++ b/spec/controllers/url_query_spec.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe 'VHost-API URL Query' do
+  # rubocop:disable Security/YAMLLoad
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  # rubocop:enable Security/YAMLLoad
+
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
@@ -27,7 +31,7 @@ describe 'VHost-API URL Query' do
         create(:domain, name: 'www.test2.com', enabled: true)
       end
 
-      context 'Searching' do
+      context 'when Searching' do
         it 'Search for strings' do
           get("/api/v#{api_version}/domains?q[name]=example.", nil,
               auth_headers_apikey(testadmin.id))
@@ -64,6 +68,7 @@ describe 'VHost-API URL Query' do
           expect(last_response.body).to eq(result)
         end
 
+        # rubocop:disable RSpec/MultipleExpectations
         it 'Search for non-existing field' do
           get("/api/v#{api_version}/domains?q[non_existing_field]=true", nil,
               auth_headers_apikey(testadmin.id))
@@ -75,9 +80,10 @@ describe 'VHost-API URL Query' do
             )
           )
         end
+        # rubocop:enable RSpec/MultipleExpectations
       end
 
-      context 'Filtering' do
+      context 'when Filtering' do
         it 'limits the return objects' do
           get("/api/v#{api_version}/domains?limit=3", nil,
               auth_headers_apikey(testadmin.id))
@@ -116,7 +122,7 @@ describe 'VHost-API URL Query' do
         end
       end
 
-      context 'Sorting' do
+      context 'when Sorting' do
         it 'Sort by name ascending' do
           get("/api/v#{api_version}/domains?sort=name", nil,
               auth_headers_apikey(testadmin.id))
@@ -158,7 +164,7 @@ describe 'VHost-API URL Query' do
         end
       end
 
-      context 'Fields' do
+      context 'when Fields' do
         it 'Only get name and id field' do
           get("/api/v#{api_version}/domains?fields=id,name", nil,
               auth_headers_apikey(testadmin.id))
@@ -217,6 +223,7 @@ describe 'VHost-API URL Query' do
           expect(last_response.body).to eq(result)
         end
 
+        # rubocop:disable RSpec/MultipleExpectations
         it 'Get non-existing field' do
           get("/api/v#{api_version}/domains?fields=id,non_existing_field", nil,
               auth_headers_apikey(testadmin.id))
@@ -228,7 +235,9 @@ describe 'VHost-API URL Query' do
             )
           )
         end
+        # rubocop:enable RSpec/MultipleExpectations
       end
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:disable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:disable RSpec/EmptyExampleGroup
+# rubocop:disable RSpec/HookArgument, RSpec/ScatteredLet
 describe 'VHost-API User Controller' do
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  api_versions = %w(1)
+  api_versions = %w[1]
 
   api_versions.each do |api_version|
     context "API version #{api_version}" do
-      context 'by an admin user' do
+      context 'when by an admin user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testgroup) { create(:group) }
@@ -115,7 +119,7 @@ describe 'VHost-API User Controller' do
         end
 
         describe 'POST' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             let(:user_packages) do
               packages = create_list(:package, 2)
               packages.map(&:id)
@@ -186,8 +190,8 @@ describe 'VHost-API User Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , name: \'foo, enabled: true }' }
 
               it 'does not create a new user' do
@@ -246,7 +250,7 @@ describe 'VHost-API User Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_user_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not create a new user' do
@@ -304,7 +308,7 @@ describe 'VHost-API User Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_user) }
 
               it 'does not create a new user' do
@@ -370,7 +374,7 @@ describe 'VHost-API User Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:resource_conflict) { attributes_for(:user, login: 'user') }
 
               it 'does not create a new user' do
@@ -414,7 +418,7 @@ describe 'VHost-API User Controller' do
         end
 
         describe 'PATCH' do
-          context 'with valid attributes' do
+          context 'when with valid attributes' do
             let(:user_packages) do
               packages = create_list(:package, 2)
               packages.map(&:id)
@@ -474,8 +478,8 @@ describe 'VHost-API User Controller' do
             end
           end
 
-          context 'with malformed request data' do
-            context 'invalid json' do
+          context 'when with malformed request data' do
+            context 'when invalid json' do
               let(:invalid_json) { '{ , name: \'foo, enabled: true }' }
 
               it 'does not update the user' do
@@ -535,7 +539,7 @@ describe 'VHost-API User Controller' do
               end
             end
 
-            context 'invalid attributes' do
+            context 'when invalid attributes' do
               let(:invalid_user_attrs) { { foo: 'bar', disabled: 1234 } }
 
               it 'does not update the user' do
@@ -594,7 +598,7 @@ describe 'VHost-API User Controller' do
               end
             end
 
-            context 'with invalid values' do
+            context 'when with invalid values' do
               let(:invalid_values) { attributes_for(:invalid_user) }
 
               it 'does not update the user' do
@@ -661,7 +665,7 @@ describe 'VHost-API User Controller' do
               end
             end
 
-            context 'with a resource conflict' do
+            context 'when with a resource conflict' do
               let(:resource_conflict) do
                 attributes_for(:user,
                                name: 'Conflict User UPDATED',
@@ -715,7 +719,7 @@ describe 'VHost-API User Controller' do
             end
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             # it 'returns an API Error' do
             #   invincibleuser = create(:user, name: 'invincible')
             #   allow(User).to receive(
@@ -782,7 +786,7 @@ describe 'VHost-API User Controller' do
             expect { JSON.parse(last_response.body) }.not_to raise_exception
           end
 
-          context 'operation failed' do
+          context 'when operation failed' do
             it 'returns an API Error' do
               invincibleuser = create(:user, name: 'invincible')
               allow(User).to receive(
@@ -822,7 +826,7 @@ describe 'VHost-API User Controller' do
         end
       end
 
-      context 'by an authenticated but unauthorized user' do
+      context 'when by an authenticated but unauthorized user' do
         let!(:admingroup) { create(:group, name: 'admin') }
         let!(:resellergroup) { create(:group, name: 'reseller') }
         let!(:testgroup) { create(:group) }
@@ -1057,7 +1061,7 @@ describe 'VHost-API User Controller' do
         end
       end
 
-      context 'by an unauthenticated (thus authentication_failed) user' do
+      context 'when by an unauthenticated (thus authentication_failed) user' do
         before(:each) do
           create(:user, name: 'admin')
           create(:user, name: 'reseller')
@@ -1149,3 +1153,7 @@ describe 'VHost-API User Controller' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups, RSpec/LetSetup
+# rubocop:enable RSpec/MultipleExpectations, Security/YAMLLoad
+# rubocop:enable RSpec/EmptyExampleGroup
+# rubocop:enable RSpec/HookArgument, RSpec/ScatteredLet

--- a/spec/factories/apikey.rb
+++ b/spec/factories/apikey.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence :random_apikey do
     SecureRandom.hex(32)
   end

--- a/spec/factories/dkim.rb
+++ b/spec/factories/dkim.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
 FactoryGirl.define do
-  keypair = SSHKey.generate(
-    type: 'RSA',
-    bits: 4096,
-    comment: nil,
-    passphrase: nil
-  )
+  keypair = SSHKey.generate(type: 'RSA', bits: 4096, comment: nil,
+                            passphrase: nil)
 
   factory :dkim, class: Dkim do
     selector 'mail'
 
-    private_key keypair.private_key
-    public_key keypair.public_key
+    private_key do
+      keypair.private_key
+    end
+    public_key do
+      keypair.public_key
+    end
+
     enabled true
 
     transient do

--- a/spec/factories/dkim.rb
+++ b/spec/factories/dkim.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   keypair = SSHKey.generate(type: 'RSA', bits: 4096, comment: nil,
                             passphrase: nil)
 

--- a/spec/factories/dkimsigning.rb
+++ b/spec/factories/dkimsigning.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :dkimsigning, class: DkimSigning do
     author 'example.com'
     enabled true

--- a/spec/factories/domain.rb
+++ b/spec/factories/domain.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence :domain_name do |n|
     "example#{n}.org"
   end

--- a/spec/factories/group.rb
+++ b/spec/factories/group.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :group, class: Group do
     name 'user'
     enabled true

--- a/spec/factories/ipv4address.rb
+++ b/spec/factories/ipv4address.rb
@@ -2,7 +2,10 @@
 
 FactoryGirl.define do
   factory :ipv4address, class: Ipv4Address do
-    address IPAddr.new('127.0.0.1')
+    address do
+      IPAddr.new('127.0.0.1')
+    end
+
     enabled true
 
     factory :invalid_ipv4address do

--- a/spec/factories/ipv4address.rb
+++ b/spec/factories/ipv4address.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :ipv4address, class: Ipv4Address do
     address do
       IPAddr.new('127.0.0.1')

--- a/spec/factories/ipv6address.rb
+++ b/spec/factories/ipv6address.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :ipv6address, class: Ipv6Address do
     address do
       IPAddr.new('fe80::1')

--- a/spec/factories/ipv6address.rb
+++ b/spec/factories/ipv6address.rb
@@ -2,7 +2,10 @@
 
 FactoryGirl.define do
   factory :ipv6address, class: Ipv6Address do
-    address IPAddr.new('fe80::1')
+    address do
+      IPAddr.new('fe80::1')
+    end
+
     enabled true
 
     factory :invalid_ipv6address do

--- a/spec/factories/mailaccount.rb
+++ b/spec/factories/mailaccount.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/BlockLength
-FactoryGirl.define do
+FactoryBot.define do
   sequence :account_email do |n|
     "test#{n}@example.org"
   end

--- a/spec/factories/mailaccount.rb
+++ b/spec/factories/mailaccount.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 FactoryGirl.define do
   sequence :account_email do |n|
     "test#{n}@example.org"
@@ -45,3 +46,4 @@ FactoryGirl.define do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/factories/mailalias.rb
+++ b/spec/factories/mailalias.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence :alias_email do |n|
     "alias#{n}@example.com"
   end

--- a/spec/factories/mailforwarding.rb
+++ b/spec/factories/mailforwarding.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence :forwarding_email do |n|
     "forwarding#{n}@example.com"
   end

--- a/spec/factories/mailsource.rb
+++ b/spec/factories/mailsource.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence :source_email do |n|
     "source#{n}@example.com"
   end

--- a/spec/factories/package.rb
+++ b/spec/factories/package.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/BlockLength
-FactoryGirl.define do
+FactoryBot.define do
   sequence :package_name do |n|
     "Package #{n}"
   end

--- a/spec/factories/package.rb
+++ b/spec/factories/package.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 FactoryGirl.define do
   sequence :package_name do |n|
     "Package #{n}"
@@ -68,3 +69,4 @@ FactoryGirl.define do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/factories/shell.rb
+++ b/spec/factories/shell.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :shell, class: Shell do
     shell '/bin/bash'
     enabled true

--- a/spec/factories/shell_user.rb
+++ b/spec/factories/shell_user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/BlockLength
-FactoryGirl.define do
+FactoryBot.define do
   sequence :shell_username do |n|
     "customer#{n}"
   end

--- a/spec/factories/shell_user.rb
+++ b/spec/factories/shell_user.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 FactoryGirl.define do
   sequence :shell_username do |n|
     "customer#{n}"
@@ -38,3 +39,4 @@ FactoryGirl.define do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/BlockLength
-FactoryGirl.define do
+FactoryBot.define do
   sequence :user_login do |n|
     "customer#{n}"
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 FactoryGirl.define do
   sequence :user_login do |n|
     "customer#{n}"
@@ -710,3 +711,4 @@ FactoryGirl.define do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/factories/vhost.rb
+++ b/spec/factories/vhost.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
 FactoryGirl.define do
   sequence :random_fqdn do |n|
     "example#{n}.org"
@@ -45,3 +46,4 @@ FactoryGirl.define do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/factories/vhost.rb
+++ b/spec/factories/vhost.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/BlockLength
-FactoryGirl.define do
+FactoryBot.define do
   sequence :random_fqdn do |n|
     "example#{n}.org"
   end

--- a/spec/feature/app_spec.rb
+++ b/spec/feature/app_spec.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe 'VHost-API Application' do
+  # rubocop:disable Security/YAMLLoad
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
 
-  context 'by an unauthenticated user' do
+  # rubocop:enable Security/YAMLLoad
+
+  context 'with an unauthenticated user' do
+    # rubocop:disable RSpec/MultipleExpectations
     it 'returns APP and API versions' do
       get '/'
       expect(last_response.status).to eq(200)
@@ -18,8 +23,10 @@ describe 'VHost-API Application' do
         )
       )
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 
+  # rubocop:disable RSpec/MultipleExpectations
   it 'returns an API Error for unexisting routes/endpoints' do
     password = 'secret'
     testuser = create(:admin, password: password)
@@ -38,4 +45,6 @@ describe 'VHost-API Application' do
       )
     )
   end
+  # rubocop:enable RSpec/MultipleExpectations
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/feature/auth_spec.rb
+++ b/spec/feature/auth_spec.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe 'VHost-API Authentication' do
+  # rubocop:disable Security/YAMLLoad
   let(:appconfig) { YAML.load(File.read('config/appconfig.yml'))['test'] }
+
+  # rubocop:enable Security/YAMLLoad
 
   let(:password) { 'muster' }
   let(:testuser) do
@@ -29,6 +33,7 @@ describe 'VHost-API Authentication' do
       expect { JSON.parse(last_response.body) }.not_to raise_exception
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'returns an apikey' do
       post '/api/v1/auth/login', auth_login_params(testuser.login, password)
 
@@ -40,6 +45,7 @@ describe 'VHost-API Authentication' do
         Apikey.first(user_id: testuser.id, comment: 'rspec').apikey
       )
     end
+    # rubocop:enable RSpec/MultipleExpectations
 
     it 'returns an API error if apikey quota exhausted' do
       params = auth_login_params(testuser.login, password)
@@ -78,3 +84,4 @@ describe 'VHost-API Authentication' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/models/apikey_spec.rb
+++ b/spec/models/apikey_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API Apikey Model' do
   it 'has a valid factory' do

--- a/spec/models/dkim_spec.rb
+++ b/spec/models/dkim_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API Dkim Model' do
   it 'has a valid factory' do

--- a/spec/models/dkimsigning_spec.rb
+++ b/spec/models/dkimsigning_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API DkimSigning Model' do
   it 'has a valid factory' do

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API Domain Model' do
   it 'has a valid factory' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API Group Model' do
   it 'has a valid factory' do

--- a/spec/models/ipv4_address_spec.rb
+++ b/spec/models/ipv4_address_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API Ipv4Address Model' do
   it 'has a valid factory' do

--- a/spec/models/ipv6_address_spec.rb
+++ b/spec/models/ipv6_address_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API Ipv6Address Model' do
   it 'has a valid factory' do

--- a/spec/models/mailaccount_spec.rb
+++ b/spec/models/mailaccount_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe 'VHost-API MailAccount Model' do
   it 'has a valid factory' do
     expect(create(:mailaccount)).to be_valid
@@ -95,3 +96,4 @@ describe 'VHost-API MailAccount Model' do
     )
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/models/mailalias_spec.rb
+++ b/spec/models/mailalias_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API MailAlias Model' do
   it 'has a valid factory' do

--- a/spec/models/mailforwarding_spec.rb
+++ b/spec/models/mailforwarding_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API MailForwarding Model' do
   it 'has a valid factory' do

--- a/spec/models/mailsource_spec.rb
+++ b/spec/models/mailsource_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API MailSource Model' do
   it 'has a valid factory' do

--- a/spec/models/shell_spec.rb
+++ b/spec/models/shell_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API Shell Model' do
   it 'has a valid factory' do

--- a/spec/models/shell_user_spec.rb
+++ b/spec/models/shell_user_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API ShellUser Model' do
   it 'has a valid factory' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,8 +53,8 @@ describe 'VHost-API User Model' do
   it 'checks ownership of a given object against itself' do
     testadmin = create(:admin)
     testuser = create(:user)
-    expect(testadmin.owner?(testuser)).to be_truthy
-    expect(testuser.owner?(testadmin)).not_to be_truthy
+    expect(testadmin.owner_of?(testuser)).to be_truthy
+    expect(testuser.owner_of?(testadmin)).not_to be_truthy
   end
 
   it 'allows checking of admin privileges' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ require File.expand_path('../spec_helper.rb', __dir__)
 
 # rubocop:disable Metrics/BlockLength
 describe 'VHost-API User Model' do
-  # rubocop:disable RSpec/MultipleExpectations
+  # rubocop:disable RSpec/MultipleExpectations, RSpec/PredicateMatcher
   it 'has a valid factory' do
     admin_group = create(:group, name: 'admin')
     expect(create(:admin, group: admin_group)).to be_valid
@@ -53,24 +53,24 @@ describe 'VHost-API User Model' do
   it 'checks ownership of a given object against itself' do
     testadmin = create(:admin)
     testuser = create(:user)
-    expect(testadmin.be_owner_of(testuser)).to be_truthy
-    expect(testuser.be_owner_of(testadmin)).not_to be_truthy
+    expect(testadmin.owner?(testuser)).to be_truthy
+    expect(testuser.owner?(testadmin)).not_to be_truthy
   end
 
   it 'allows checking of admin privileges' do
     testadmin = build(:admin)
     testreseller = build(:reseller)
     testuser = build(:user)
-    expect(testadmin.be_admin).to be_truthy
-    expect(testreseller.be_admin).not_to be_truthy
-    expect(testuser.be_admin).not_to be_truthy
+    expect(testadmin.admin?).to be_truthy
+    expect(testreseller.admin?).not_to be_truthy
+    expect(testuser.admin?).not_to be_truthy
   end
 
   it 'allows checking of reseller privileges' do
     testreseller = build(:reseller)
     testuser = build(:user)
-    expect(testreseller.be_reseller).to be_truthy
-    expect(testuser.be_reseller).not_to be_truthy
+    expect(testreseller.reseller?).to be_truthy
+    expect(testuser.reseller?).not_to be_truthy
   end
 
   it 'returns the owner as a User object' do
@@ -78,6 +78,6 @@ describe 'VHost-API User Model' do
     testuser = create(:user)
     expect(testuser.owner).to be_an_instance_of(User)
   end
-  # rubocop:enable RSpec/MultipleExpectations
+  # rubocop:enable RSpec/MultipleExpectations, RSpec/PredicateMatcher
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe 'VHost-API User Model' do
+  # rubocop:disable RSpec/MultipleExpectations
   it 'has a valid factory' do
     admin_group = create(:group, name: 'admin')
     expect(create(:admin, group: admin_group)).to be_valid
@@ -51,24 +53,24 @@ describe 'VHost-API User Model' do
   it 'checks ownership of a given object against itself' do
     testadmin = create(:admin)
     testuser = create(:user)
-    expect(testadmin.owner_of?(testuser)).to be_truthy
-    expect(testuser.owner_of?(testadmin)).not_to be_truthy
+    expect(testadmin.be_owner_of(testuser)).to be_truthy
+    expect(testuser.be_owner_of(testadmin)).not_to be_truthy
   end
 
   it 'allows checking of admin privileges' do
     testadmin = build(:admin)
     testreseller = build(:reseller)
     testuser = build(:user)
-    expect(testadmin.admin?).to be_truthy
-    expect(testreseller.admin?).not_to be_truthy
-    expect(testuser.admin?).not_to be_truthy
+    expect(testadmin.be_admin).to be_truthy
+    expect(testreseller.be_admin).not_to be_truthy
+    expect(testuser.be_admin).not_to be_truthy
   end
 
   it 'allows checking of reseller privileges' do
     testreseller = build(:reseller)
     testuser = build(:user)
-    expect(testreseller.reseller?).to be_truthy
-    expect(testuser.reseller?).not_to be_truthy
+    expect(testreseller.be_reseller).to be_truthy
+    expect(testuser.be_reseller).not_to be_truthy
   end
 
   it 'returns the owner as a User object' do
@@ -76,4 +78,6 @@ describe 'VHost-API User Model' do
     testuser = create(:user)
     expect(testuser.owner).to be_an_instance_of(User)
   end
+  # rubocop:enable RSpec/MultipleExpectations
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/models/vhost.rb
+++ b/spec/models/vhost.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe 'VHost-API Vhost Model' do
   it 'has a valid factory' do

--- a/spec/policies/apikey_policy_spec.rb
+++ b/spec/policies/apikey_policy_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe ApikeyPolicy do
   subject { described_class.new(user, apikey) }
 
@@ -9,30 +10,30 @@ describe ApikeyPolicy do
     FactoryGirl.create(:apikey)
   end
 
-  context 'for the owner' do
+  context 'when being the owner' do
     let(:user) { create(:user_with_apikeys) }
     let(:apikey) { user.apikeys.first }
     let(:otheruser) { create(:user) }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) { create(:user_with_apikeys_and_exhausted_apikey_quota) }
       let(:apikey) { user.apikeys.first }
 
       it { is_expected.not_to permit(:create) }
     end
 
-    context 'assigning to another user' do
+    context 'when assigning to another user' do
       let(:params) { attributes_for(:apikey, user_id: otheruser.id) }
 
       it { is_expected.not_to permit_args(:update_with, params) }
       it { is_expected.not_to permit_args(:create_with, params) }
     end
 
-    context 'changing attributes w/o changing the owner' do
+    context 'when changing attributes w/o changing the owner' do
       let(:params) { attributes_for(:apikey, id: apikey.id, user_id: user.id) }
 
       it { is_expected.to permit(:update) }
@@ -43,7 +44,7 @@ describe ApikeyPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'changing the id as an unauthorized user' do
+  context 'when changing the id as an unauthorized user' do
     let(:user) { create(:user_with_apikeys) }
     let(:apikey) { user.apikeys.first }
     let(:params) { attributes_for(:apikey, id: 1234) }
@@ -51,16 +52,16 @@ describe ApikeyPolicy do
     it { is_expected.not_to permit_args(:update_with, params) }
   end
 
-  context 'for another unprivileged user' do
+  context 'when being another unprivileged user' do
     let(:owner) { create(:user_with_apikeys) }
     let(:user) { create(:user) }
     let(:apikey) { owner.apikeys.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) { create(:user_with_apikeys_and_exhausted_apikey_quota) }
       let(:user) { create(:user_with_exhausted_apikey_quota) }
       let(:apikey) { owner.apikeys.first }
@@ -73,16 +74,16 @@ describe ApikeyPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for the reseller of the user' do
+  context 'when being the reseller of the user' do
     let(:user) { create(:reseller_with_customers_and_apikeys) }
     let(:owner) { user.customers.first }
     let(:apikey) { owner.apikeys.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) do
         create(:reseller_with_customers_and_apikeys_and_exhausted_apikey_quota)
       end
@@ -97,16 +98,16 @@ describe ApikeyPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'for another unprivileged reseller' do
+  context 'when being another unprivileged reseller' do
     let(:owner) { create(:reseller_with_customers_and_apikeys) }
     let(:user) { create(:reseller) }
     let(:apikey) { owner.customers.first.apikeys.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) { create(:reseller_with_customers_and_apikeys) }
       let(:user) { create(:reseller_with_exhausted_apikey_quota) }
       let(:apikey) { owner.apikeys.first }
@@ -119,7 +120,7 @@ describe ApikeyPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for an admin' do
+  context 'when being an admin' do
     let(:user) { create(:admin) }
 
     it { is_expected.to permit(:show) }
@@ -128,3 +129,4 @@ describe ApikeyPolicy do
     it { is_expected.to permit(:destroy) }
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/policies/apikey_policy_spec.rb
+++ b/spec/policies/apikey_policy_spec.rb
@@ -7,7 +7,7 @@ describe ApikeyPolicy do
   subject { described_class.new(user, apikey) }
 
   let(:apikey) do
-    FactoryGirl.create(:apikey)
+    FactoryBot.create(:apikey)
   end
 
   context 'when being the owner' do

--- a/spec/policies/dkim_policy_spec.rb
+++ b/spec/policies/dkim_policy_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe DkimPolicy do
   subject { described_class.new(user, dkim) }
 
@@ -9,14 +10,14 @@ describe DkimPolicy do
     FactoryGirl.create(:dkim)
   end
 
-  context 'for the owner' do
+  context 'when being the owner' do
     let(:user) { create(:user_with_dkims) }
     let(:dkim) { user.domains.dkims.first }
     let(:otheruser) { create(:user_with_domains) }
 
     it { is_expected.to permit(:create) }
 
-    context 'assigning to another unauthorized domain' do
+    context 'when assigning to another unauthorized domain' do
       let(:params) do
         attributes_for(:dkim, domain_id: otheruser.domains.first.id)
       end
@@ -25,7 +26,7 @@ describe DkimPolicy do
       it { is_expected.not_to permit_args(:create_with, params) }
     end
 
-    context 'changing attributes w/o changing the owner' do
+    context 'when changing attributes w/o changing the owner' do
       let(:params) do
         attributes_for(:dkim, id: dkim.id, domain_id: user.domains.first.id)
       end
@@ -38,7 +39,7 @@ describe DkimPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'for another unprivileged user' do
+  context 'when being another unprivileged user' do
     let(:owner) { create(:user_with_dkims) }
     let(:user) { create(:user) }
     let(:dkim) { owner.domains.dkims.first }
@@ -49,7 +50,7 @@ describe DkimPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for the reseller of the user' do
+  context 'when being the reseller of the user' do
     let(:user) { create(:reseller_with_customers_and_dkims) }
     let(:owner) { user.customers.first }
     let(:dkim) { owner.domains.dkims.first }
@@ -60,7 +61,7 @@ describe DkimPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'changing the id as an unauthorized user' do
+  context 'when changing the id as an unauthorized user' do
     let(:user) { create(:user_with_dkims) }
     let(:dkim) { user.domains.first.dkims.first }
     let(:params) { attributes_for(:dkim, id: 1234) }
@@ -68,7 +69,7 @@ describe DkimPolicy do
     it { is_expected.not_to permit_args(:update_with, params) }
   end
 
-  context 'for another unprivileged reseller' do
+  context 'when being another unprivileged reseller' do
     let(:owner) { create(:reseller_with_customers_and_dkims) }
     let(:user) { create(:reseller) }
     let(:dkim) { owner.customers.first.domains.dkims.first }
@@ -79,7 +80,7 @@ describe DkimPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for an admin' do
+  context 'when being an admin' do
     let(:user) { create(:admin) }
 
     it { is_expected.to permit(:show) }
@@ -88,3 +89,4 @@ describe DkimPolicy do
     it { is_expected.to permit(:destroy) }
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/policies/dkim_policy_spec.rb
+++ b/spec/policies/dkim_policy_spec.rb
@@ -7,7 +7,7 @@ describe DkimPolicy do
   subject { described_class.new(user, dkim) }
 
   let(:dkim) do
-    FactoryGirl.create(:dkim)
+    FactoryBot.create(:dkim)
   end
 
   context 'when being the owner' do

--- a/spec/policies/dkim_signing_policy_spec.rb
+++ b/spec/policies/dkim_signing_policy_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe DkimSigningPolicy do
   subject { described_class.new(user, dkimsigning) }
 
@@ -9,14 +10,14 @@ describe DkimSigningPolicy do
     FactoryGirl.create(:dkimsigning)
   end
 
-  context 'for the owner' do
+  context 'when being the owner' do
     let(:user) { create(:user_with_dkimsignings) }
     let(:dkimsigning) { user.domains.first.dkims.first.dkim_signings.first }
     let(:otheruser) { create(:user_with_dkims) }
 
     it { is_expected.to permit(:create) }
 
-    context 'assigning to another unauthorized domain' do
+    context 'when assigning to another unauthorized domain' do
       let(:params) do
         attributes_for(:dkimsigning,
                        dkim_id: otheruser.domains.first.dkims.first.id)
@@ -26,7 +27,7 @@ describe DkimSigningPolicy do
       it { is_expected.not_to permit_args(:create_with, params) }
     end
 
-    context 'changing attributes w/o changing the owner' do
+    context 'when changing attributes w/o changing the owner' do
       let(:params) do
         attributes_for(:dkimsigning,
                        id: dkimsigning.id,
@@ -41,7 +42,7 @@ describe DkimSigningPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'for another unprivileged user' do
+  context 'when being another unprivileged user' do
     let(:owner) { create(:user_with_dkimsignings) }
     let(:user) { create(:user) }
     let(:dkimsigning) { owner.domains.first.dkims.first.dkim_signings.first }
@@ -52,7 +53,7 @@ describe DkimSigningPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for the reseller of the user' do
+  context 'when being the reseller of the user' do
     let(:user) { create(:reseller_with_customers_and_dkimsignings) }
     let(:owner) { user.customers.first }
     let(:dkimsigning) { owner.domains.first.dkims.first.dkim_signings.first }
@@ -63,7 +64,7 @@ describe DkimSigningPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'changing the id as an unauthorized user' do
+  context 'when changing the id as an unauthorized user' do
     let(:user) { create(:user_with_dkimsignings) }
     let(:dkimsigning) { user.domains.first.dkims.first.dkim_signings.first }
     let(:params) { attributes_for(:dkimsigning, id: 1234) }
@@ -71,7 +72,7 @@ describe DkimSigningPolicy do
     it { is_expected.not_to permit_args(:update_with, params) }
   end
 
-  context 'for another unprivileged reseller' do
+  context 'when being another unprivileged reseller' do
     let(:owner) { create(:reseller_with_customers_and_dkimsignings) }
     let(:user) { create(:reseller) }
     let(:dkimsigning) do
@@ -84,7 +85,7 @@ describe DkimSigningPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for an admin' do
+  context 'when being an admin' do
     let(:user) { create(:admin) }
 
     it { is_expected.to permit(:show) }
@@ -93,3 +94,4 @@ describe DkimSigningPolicy do
     it { is_expected.to permit(:destroy) }
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/policies/dkim_signing_policy_spec.rb
+++ b/spec/policies/dkim_signing_policy_spec.rb
@@ -7,7 +7,7 @@ describe DkimSigningPolicy do
   subject { described_class.new(user, dkimsigning) }
 
   let(:dkimsigning) do
-    FactoryGirl.create(:dkimsigning)
+    FactoryBot.create(:dkimsigning)
   end
 
   context 'when being the owner' do

--- a/spec/policies/domain_policy_spec.rb
+++ b/spec/policies/domain_policy_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe DomainPolicy do
   subject { described_class.new(user, domain) }
 
@@ -9,30 +10,30 @@ describe DomainPolicy do
     FactoryGirl.create(:domain)
   end
 
-  context 'for the owner' do
+  context 'when being the owner' do
     let(:user) { create(:user_with_domains) }
     let(:domain) { user.domains.first }
     let(:otheruser) { create(:user) }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) { create(:user_with_domains_and_exhausted_domain_quota) }
       let(:domain) { user.domains.first }
 
       it { is_expected.not_to permit(:create) }
     end
 
-    context 'assigning to another user' do
+    context 'when assigning to another user' do
       let(:params) { attributes_for(:domain, user_id: otheruser.id) }
 
       it { is_expected.not_to permit_args(:update_with, params) }
       it { is_expected.not_to permit_args(:create_with, params) }
     end
 
-    context 'changing attributes w/o changing the owner' do
+    context 'when changing attributes w/o changing the owner' do
       let(:params) { attributes_for(:domain, id: domain.id, user_id: user.id) }
 
       it { is_expected.to permit(:update) }
@@ -43,7 +44,7 @@ describe DomainPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'changing the id as an unauthorized user' do
+  context 'when changing the id as an unauthorized user' do
     let(:user) { create(:user_with_domains) }
     let(:domain) { user.domains.first }
     let(:params) { attributes_for(:domain, id: 1234) }
@@ -51,16 +52,16 @@ describe DomainPolicy do
     it { is_expected.not_to permit_args(:update_with, params) }
   end
 
-  context 'for another unprivileged user' do
+  context 'when being another unprivileged user' do
     let(:owner) { create(:user_with_domains) }
     let(:user) { create(:user) }
     let(:domain) { owner.domains.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) { create(:user_with_domains_and_exhausted_domain_quota) }
       let(:user) { create(:user_with_exhausted_domain_quota) }
       let(:domain) { owner.domains.first }
@@ -73,16 +74,16 @@ describe DomainPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for the reseller of the user' do
+  context 'when being the reseller of the user' do
     let(:user) { create(:reseller_with_customers_and_domains) }
     let(:owner) { user.customers.first }
     let(:domain) { owner.domains.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) do
         create(:reseller_with_customers_and_domains_and_exhausted_domain_quota)
       end
@@ -97,16 +98,16 @@ describe DomainPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'for another unprivileged reseller' do
+  context 'when being another unprivileged reseller' do
     let(:owner) { create(:reseller_with_customers_and_domains) }
     let(:user) { create(:reseller) }
     let(:domain) { owner.customers.first.domains.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) { create(:reseller_with_customers_and_domains) }
       let(:user) { create(:reseller_with_exhausted_domain_quota) }
       let(:domain) { owner.domains.first }
@@ -119,7 +120,7 @@ describe DomainPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for an admin' do
+  context 'when being an admin' do
     let(:user) { create(:admin) }
 
     it { is_expected.to permit(:show) }
@@ -128,3 +129,4 @@ describe DomainPolicy do
     it { is_expected.to permit(:destroy) }
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/policies/domain_policy_spec.rb
+++ b/spec/policies/domain_policy_spec.rb
@@ -7,7 +7,7 @@ describe DomainPolicy do
   subject { described_class.new(user, domain) }
 
   let(:domain) do
-    FactoryGirl.create(:domain)
+    FactoryBot.create(:domain)
   end
 
   context 'when being the owner' do

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
 describe GroupPolicy do
   subject { described_class.new(user, group) }
 
   let(:group) { FactoryGirl.create(:group, name: 'testgroup') }
 
-  context 'for a user' do
+  context 'with a user' do
     let(:user) { FactoryGirl.create(:user) }
 
     it { is_expected.not_to permit(:show)    }
@@ -16,7 +16,7 @@ describe GroupPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for a reseller' do
+  context 'with a reseller' do
     let(:user) { FactoryGirl.create(:reseller) }
 
     it { is_expected.not_to permit(:show)    }
@@ -25,7 +25,7 @@ describe GroupPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for an admin' do
+  context 'with an admin' do
     let(:user) { FactoryGirl.create(:admin) }
 
     it { is_expected.to permit(:show)    }

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -5,10 +5,10 @@ require File.expand_path('../spec_helper.rb', __dir__)
 describe GroupPolicy do
   subject { described_class.new(user, group) }
 
-  let(:group) { FactoryGirl.create(:group, name: 'testgroup') }
+  let(:group) { FactoryBot.create(:group, name: 'testgroup') }
 
   context 'with a user' do
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
 
     it { is_expected.not_to permit(:show)    }
     it { is_expected.not_to permit(:create)  }
@@ -17,7 +17,7 @@ describe GroupPolicy do
   end
 
   context 'with a reseller' do
-    let(:user) { FactoryGirl.create(:reseller) }
+    let(:user) { FactoryBot.create(:reseller) }
 
     it { is_expected.not_to permit(:show)    }
     it { is_expected.not_to permit(:create)  }
@@ -26,7 +26,7 @@ describe GroupPolicy do
   end
 
   context 'with an admin' do
-    let(:user) { FactoryGirl.create(:admin) }
+    let(:user) { FactoryBot.create(:admin) }
 
     it { is_expected.to permit(:show)    }
     it { is_expected.to permit(:create)  }

--- a/spec/policies/mail_account_policy_spec.rb
+++ b/spec/policies/mail_account_policy_spec.rb
@@ -7,7 +7,7 @@ describe MailAccountPolicy do
   subject { described_class.new(user, mailaccount) }
 
   let(:mailaccount) do
-    FactoryGirl.create(:mailaccount)
+    FactoryBot.create(:mailaccount)
   end
 
   context 'when being the owner' do

--- a/spec/policies/mail_account_policy_spec.rb
+++ b/spec/policies/mail_account_policy_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups
 describe MailAccountPolicy do
   subject { described_class.new(user, mailaccount) }
 
@@ -9,17 +10,17 @@ describe MailAccountPolicy do
     FactoryGirl.create(:mailaccount)
   end
 
-  context 'for the owner' do
+  context 'when being the owner' do
     let(:user) { create(:user_with_mailaccounts) }
     let(:mailaccount) { user.domains.mail_accounts.first }
     let(:otheruser) { create(:user_with_domains) }
 
-    context 'with available quota' do
-      context 'CREATE allocation request smaller than remaining quota' do
+    context 'when with available quota' do
+      context 'when CREATE allocation request smaller than remaining quota' do
         it { is_expected.to permit(:create) }
       end
 
-      context 'UPDATE allocation request smaller than remaining quota' do
+      context 'when UPDATE allocation request smaller than remaining quota' do
         let(:params) do
           policy = Pundit.policy(user, mailaccount)
           available = mailaccount.quota + policy.storage_remaining
@@ -33,7 +34,7 @@ describe MailAccountPolicy do
       end
     end
 
-    context 'CREATE allocation request exceeding remaining quota' do
+    context 'when CREATE allocation request exceeding remaining quota' do
       let(:params) do
         attributes_for(:mailaccount,
                        domain_id: user.domains.first.id,
@@ -45,7 +46,7 @@ describe MailAccountPolicy do
       it { is_expected.not_to permit_args(:create_with, params) }
     end
 
-    context 'UPDATE allocation request exceeding remaining quota' do
+    context 'when UPDATE allocation request exceeding remaining quota' do
       let(:params) do
         policy = Pundit.policy(user, mailaccount)
         too_much = mailaccount.quota + policy.storage_remaining + 1
@@ -57,7 +58,7 @@ describe MailAccountPolicy do
       it { is_expected.not_to permit_args(:update_with, params) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) do
         create(:user_with_mailaccounts_and_exhausted_mailaccount_quota)
       end
@@ -66,7 +67,7 @@ describe MailAccountPolicy do
       it { is_expected.not_to permit(:create) }
     end
 
-    context 'assigning to another user' do
+    context 'when assigning to another user' do
       let(:params) do
         attributes_for(:mailaccount, domain_id: otheruser.domains.first.id)
       end
@@ -75,7 +76,7 @@ describe MailAccountPolicy do
       it { is_expected.not_to permit_args(:create_with, params) }
     end
 
-    context 'changing the id as an unauthorized user' do
+    context 'when changing the id as an unauthorized user' do
       let(:params) do
         attributes_for(:mailaccount,
                        id: 1234,
@@ -85,7 +86,7 @@ describe MailAccountPolicy do
       it { is_expected.not_to permit_args(:update_with, params) }
     end
 
-    context 'changing attributes w/o changing the owner' do
+    context 'when changing attributes w/o changing the owner' do
       let(:params) do
         attributes_for(:mailaccount, domain_id: user.domains.first.id)
       end
@@ -98,16 +99,16 @@ describe MailAccountPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'for another unprivileged user' do
+  context 'when being another unprivileged user' do
     let(:owner) { create(:user_with_mailaccounts) }
     let(:user) { create(:user) }
     let(:mailaccount) { owner.domains.mail_accounts.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) do
         create(:user_with_mailaccounts_and_exhausted_mailaccount_quota)
       end
@@ -122,16 +123,16 @@ describe MailAccountPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for the reseller of the user' do
+  context 'when being the reseller of the user' do
     let(:user) { create(:reseller_with_customers_and_mailaccounts) }
     let(:owner) { user.customers.first }
     let(:mailaccount) { owner.domains.mail_accounts.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) do
         create(:reseller_with_customers_and_mailaccounts_and_exhausted_quota)
       end
@@ -147,16 +148,16 @@ describe MailAccountPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'for another unprivileged reseller' do
+  context 'when being another unprivileged reseller' do
     let(:owner) { create(:reseller_with_customers_and_mailaccounts) }
     let(:user) { create(:reseller) }
     let(:mailaccount) { owner.customers.first.domains.mail_accounts.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) { create(:reseller_with_customers_and_mailaccounts) }
       let(:user) { create(:reseller_with_exhausted_mailaccount_quota) }
       let(:mailaccount) { owner.domains.mail_accounts.first }
@@ -169,7 +170,7 @@ describe MailAccountPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for an admin' do
+  context 'when being an admin' do
     let(:user) { create(:admin) }
 
     it { is_expected.to permit(:show) }
@@ -178,3 +179,4 @@ describe MailAccountPolicy do
     it { is_expected.to permit(:destroy) }
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups

--- a/spec/policies/mail_alias_policy_spec.rb
+++ b/spec/policies/mail_alias_policy_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe MailAliasPolicy do
   subject { described_class.new(user, mailalias) }
 
@@ -9,16 +10,16 @@ describe MailAliasPolicy do
     FactoryGirl.create(:mailalias)
   end
 
-  context 'for the owner' do
+  context 'when being the owner' do
     let(:user) { create(:user_with_mailaliases) }
     let(:mailalias) { user.domains.mail_aliases.first }
     let(:otheruser) { create(:user_with_domains) }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) do
         create(:user_with_mailaliases_and_exhausted_mailalias_quota)
       end
@@ -27,7 +28,7 @@ describe MailAliasPolicy do
       it { is_expected.not_to permit(:create) }
     end
 
-    context 'assigning to another unauthorized domain' do
+    context 'when assigning to another unauthorized domain' do
       let(:params) do
         attributes_for(:mailalias, domain_id: otheruser.domains.first.id)
       end
@@ -36,7 +37,7 @@ describe MailAliasPolicy do
       it { is_expected.not_to permit_args(:create_with, params) }
     end
 
-    context 'changing attributes w/o changing the owner' do
+    context 'when changing attributes w/o changing the owner' do
       let(:params) do
         attributes_for(:mailalias,
                        id: mailalias.id,
@@ -51,7 +52,7 @@ describe MailAliasPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'changing the id as an unauthorized user' do
+  context 'when changing the id as an unauthorized user' do
     let(:user) { create(:user_with_mailaliases) }
     let(:mailalias) { user.domains.first.mail_aliases.first }
     let(:params) { attributes_for(:mailalias, id: 1234) }
@@ -59,16 +60,16 @@ describe MailAliasPolicy do
     it { is_expected.not_to permit_args(:update_with, params) }
   end
 
-  context 'for another unprivileged user' do
+  context 'when being another unprivileged user' do
     let(:owner) { create(:user_with_mailaliases) }
     let(:user) { create(:user) }
     let(:mailalias) { owner.domains.mail_aliases.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) do
         create(:user_with_mailaliases_and_exhausted_mailalias_quota)
       end
@@ -83,7 +84,7 @@ describe MailAliasPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for the reseller of the user' do
+  context 'when being the reseller of the user' do
     let(:user) { create(:reseller_with_customers_and_mailaliases) }
     let(:owner) { user.customers.first }
     let(:mailalias) { owner.domains.mail_aliases.first }
@@ -96,11 +97,11 @@ describe MailAliasPolicy do
 
     it { is_expected.to permit_args(:create_with, params) }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) do
         create(:reseller_with_customers_and_mailaliases_and_exhausted_quota)
       end
@@ -116,16 +117,16 @@ describe MailAliasPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'for another unprivileged reseller' do
+  context 'when being another unprivileged reseller' do
     let(:owner) { create(:reseller_with_customers_and_mailaliases) }
     let(:user) { create(:reseller) }
     let(:mailalias) { owner.customers.first.domains.mail_aliases.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) { create(:reseller_with_customers_and_mailaliases) }
       let(:user) { create(:reseller_with_exhausted_mailalias_quota) }
       let(:mailalias) { owner.domains.mail_aliases.first }
@@ -138,7 +139,7 @@ describe MailAliasPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for an admin' do
+  context 'when being an admin' do
     let(:user) { create(:admin) }
 
     it { is_expected.to permit(:show) }
@@ -147,3 +148,4 @@ describe MailAliasPolicy do
     it { is_expected.to permit(:destroy) }
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/policies/mail_alias_policy_spec.rb
+++ b/spec/policies/mail_alias_policy_spec.rb
@@ -7,7 +7,7 @@ describe MailAliasPolicy do
   subject { described_class.new(user, mailalias) }
 
   let(:mailalias) do
-    FactoryGirl.create(:mailalias)
+    FactoryBot.create(:mailalias)
   end
 
   context 'when being the owner' do

--- a/spec/policies/mail_forwarding_policy_spec.rb
+++ b/spec/policies/mail_forwarding_policy_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe MailForwardingPolicy do
   subject { described_class.new(user, mailforwarding) }
 
@@ -9,16 +10,16 @@ describe MailForwardingPolicy do
     FactoryGirl.create(:mailforwarding)
   end
 
-  context 'for the owner' do
+  context 'when being the owner' do
     let(:user) { create(:user_with_mailforwardings) }
     let(:mailforwarding) { user.domains.mail_forwardings.first }
     let(:otheruser) { create(:user_with_domains) }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) do
         create(:user_with_mailforwardings_and_exhausted_mailforwarding_quota)
       end
@@ -27,7 +28,7 @@ describe MailForwardingPolicy do
       it { is_expected.not_to permit(:create) }
     end
 
-    context 'assigning to another unauthorized domain' do
+    context 'when assigning to another unauthorized domain' do
       let(:params) do
         attributes_for(:mailforwarding, domain_id: otheruser.domains.first.id)
       end
@@ -36,7 +37,7 @@ describe MailForwardingPolicy do
       it { is_expected.not_to permit_args(:create_with, params) }
     end
 
-    context 'changing attributes w/o changing the owner' do
+    context 'when changing attributes w/o changing the owner' do
       let(:params) do
         attributes_for(:mailforwarding,
                        id: mailforwarding.id,
@@ -51,7 +52,7 @@ describe MailForwardingPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'changing the id as an unauthorized user' do
+  context 'when changing the id as an unauthorized user' do
     let(:user) { create(:user_with_mailforwardings) }
     let(:mailforwarding) { user.domains.first.mail_forwardings.first }
     let(:params) { attributes_for(:mailforwarding, id: 1234) }
@@ -59,16 +60,16 @@ describe MailForwardingPolicy do
     it { is_expected.not_to permit_args(:update_with, params) }
   end
 
-  context 'for another unprivileged user' do
+  context 'when being another unprivileged user' do
     let(:owner) { create(:user_with_mailforwardings) }
     let(:user) { create(:user) }
     let(:mailforwarding) { owner.domains.mail_forwardings.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) do
         create(:user_with_mailforwardings_and_exhausted_mailforwarding_quota)
       end
@@ -83,7 +84,7 @@ describe MailForwardingPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for the reseller of the user' do
+  context 'when being the reseller of the user' do
     let(:user) { create(:reseller_with_customers_and_mailforwardings) }
     let(:owner) { user.customers.first }
     let(:mailforwarding) { owner.domains.mail_forwardings.first }
@@ -94,11 +95,11 @@ describe MailForwardingPolicy do
 
     it { is_expected.to permit_args(:create_with, params) }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) do
         create(:reseller_with_customers_and_mailforwardings_and_exhausted_quota)
       end
@@ -114,18 +115,18 @@ describe MailForwardingPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'for another unprivileged reseller' do
+  context 'when being another unprivileged reseller' do
     let(:owner) { create(:reseller_with_customers_and_mailforwardings) }
     let(:user) { create(:reseller) }
     let(:mailforwarding) do
       owner.customers.first.domains.mail_forwardings.first
     end
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) { create(:reseller_with_customers_and_mailforwardings) }
       let(:user) { create(:reseller_with_exhausted_mailforwarding_quota) }
       let(:mailforwarding) { owner.domains.mail_forwardings.first }
@@ -138,7 +139,7 @@ describe MailForwardingPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for an admin' do
+  context 'when being an admin' do
     let(:user) { create(:admin) }
 
     it { is_expected.to permit(:show) }
@@ -147,3 +148,4 @@ describe MailForwardingPolicy do
     it { is_expected.to permit(:destroy) }
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/policies/mail_forwarding_policy_spec.rb
+++ b/spec/policies/mail_forwarding_policy_spec.rb
@@ -7,7 +7,7 @@ describe MailForwardingPolicy do
   subject { described_class.new(user, mailforwarding) }
 
   let(:mailforwarding) do
-    FactoryGirl.create(:mailforwarding)
+    FactoryBot.create(:mailforwarding)
   end
 
   context 'when being the owner' do

--- a/spec/policies/mail_source_policy_spec.rb
+++ b/spec/policies/mail_source_policy_spec.rb
@@ -7,7 +7,7 @@ describe MailSourcePolicy do
   subject { described_class.new(user, mailsource) }
 
   let(:mailsource) do
-    FactoryGirl.create(:mailsource)
+    FactoryBot.create(:mailsource)
   end
 
   context 'when being the owner' do

--- a/spec/policies/mail_source_policy_spec.rb
+++ b/spec/policies/mail_source_policy_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 describe MailSourcePolicy do
   subject { described_class.new(user, mailsource) }
 
@@ -9,16 +10,16 @@ describe MailSourcePolicy do
     FactoryGirl.create(:mailsource)
   end
 
-  context 'for the owner' do
+  context 'when being the owner' do
     let(:user) { create(:user_with_mailsources) }
     let(:mailsource) { user.domains.mail_sources.first }
     let(:otheruser) { create(:user_with_domains) }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) do
         create(:user_with_mailsources_and_exhausted_mailsource_quota)
       end
@@ -27,7 +28,7 @@ describe MailSourcePolicy do
       it { is_expected.not_to permit(:create) }
     end
 
-    context 'assigning to another unauthorized domain' do
+    context 'when assigning to another unauthorized domain' do
       let(:params) do
         attributes_for(:mailsource, domain_id: otheruser.domains.first.id)
       end
@@ -36,7 +37,7 @@ describe MailSourcePolicy do
       it { is_expected.not_to permit_args(:create_with, params) }
     end
 
-    context 'changing attributes w/o changing the owner' do
+    context 'when changing attributes w/o changing the owner' do
       let(:params) do
         attributes_for(:mailsource,
                        id: mailsource.id,
@@ -51,7 +52,7 @@ describe MailSourcePolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'changing the id as an unauthorized user' do
+  context 'when changing the id as an unauthorized user' do
     let(:user) { create(:user_with_mailsources) }
     let(:mailsource) { user.domains.first.mail_sources.first }
     let(:params) { attributes_for(:mailsource, id: 1234) }
@@ -59,16 +60,16 @@ describe MailSourcePolicy do
     it { is_expected.not_to permit_args(:update_with, params) }
   end
 
-  context 'for another unprivileged user' do
+  context 'when being another unprivileged user' do
     let(:owner) { create(:user_with_mailsources) }
     let(:user) { create(:user) }
     let(:mailsource) { owner.domains.mail_sources.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) do
         create(:user_with_mailsources_and_exhausted_mailsource_quota)
       end
@@ -83,7 +84,7 @@ describe MailSourcePolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for the reseller of the user' do
+  context 'when being the reseller of the user' do
     let(:user) { create(:reseller_with_customers_and_mailsources) }
     let(:owner) { user.customers.first }
     let(:mailsource) { owner.domains.mail_sources.first }
@@ -96,11 +97,11 @@ describe MailSourcePolicy do
 
     it { is_expected.to permit_args(:create_with, params) }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) do
         create(:reseller_with_customers_and_mailsources_and_exhausted_quota)
       end
@@ -116,16 +117,16 @@ describe MailSourcePolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'for another unprivileged reseller' do
+  context 'when being another unprivileged reseller' do
     let(:owner) { create(:reseller_with_customers_and_mailsources) }
     let(:user) { create(:reseller) }
     let(:mailsource) { owner.customers.first.domains.mail_sources.first }
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:owner) { create(:reseller_with_customers_and_mailsources) }
       let(:user) { create(:reseller_with_exhausted_mailsource_quota) }
       let(:mailsource) { owner.domains.mail_sources.first }
@@ -138,7 +139,7 @@ describe MailSourcePolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for an admin' do
+  context 'when being an admin' do
     let(:user) { create(:admin) }
 
     it { is_expected.to permit(:show) }
@@ -147,3 +148,4 @@ describe MailSourcePolicy do
     it { is_expected.to permit(:destroy) }
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/policies/package_policy_spec.rb
+++ b/spec/policies/package_policy_spec.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups
 describe PackagePolicy do
   subject { described_class.new(user, package) }
 
   let(:package) { FactoryGirl.create(:package, name: 'testpackage') }
 
-  context 'for a user' do
+  context 'when being a user' do
     let(:user) { FactoryGirl.create(:user) }
 
-    context 'user has booked this package' do
+    context 'when user has booked this package' do
       let(:package) { user.packages.first }
 
       it { is_expected.to permit(:show) }
     end
 
-    context 'user has not booked this package' do
+    context 'when user has not booked this package' do
       it { is_expected.not_to permit(:show) }
     end
 
@@ -25,20 +26,20 @@ describe PackagePolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for a reseller' do
+  context 'when being a reseller' do
     let(:user) { FactoryGirl.create(:reseller) }
 
-    context 'user has booked this package' do
+    context 'when user has booked this package' do
       let(:package) { user.packages.first }
 
       it { is_expected.to permit(:show) }
     end
 
-    context 'user has not booked this package' do
+    context 'when user has not booked this package' do
       it { is_expected.not_to permit(:show) }
     end
 
-    context 'with remaining custom_packages quota' do
+    context 'when with remaining custom_packages quota' do
       let(:params) { attributes_for(:package, user_id: user.id) }
 
       it { is_expected.to permit(:create) }
@@ -52,20 +53,20 @@ describe PackagePolicy do
       it { is_expected.not_to permit_args(:create_with, params) }
     end
 
-    context 'with exhausted custom_packages quota' do
+    context 'when with exhausted custom_packages quota' do
       let(:user) { create(:reseller_with_exhausted_custom_packages_quota) }
 
       it { is_expected.not_to permit(:create) }
     end
 
-    context 'modifying their own custom packages' do
-      context 'with trying to allocate less than available quotas' do
+    context 'when modifying their own custom packages' do
+      context 'when with trying to allocate less than available quotas' do
         let(:package) { create(:package, user_id: user.id) }
 
         it { is_expected.to permit(:update) }
       end
 
-      context 'with trying to allocate more than available quotas' do
+      context 'when with trying to allocate more than available quotas' do
         let(:package) { create(:package, user_id: user.id) }
         let(:testcustomer) { create(:user, reseller_id: user.id) }
         let(:params) do
@@ -83,7 +84,7 @@ describe PackagePolicy do
         it { is_expected.not_to permit_args(:update_with, params) }
       end
 
-      context 'package is used by customers' do
+      context 'when package is used by customers' do
         let(:package) { create(:package, user_id: user.id) }
         let(:testcustomer) { create(:user, reseller_id: user.id) }
         let(:params) do
@@ -102,14 +103,14 @@ describe PackagePolicy do
         it { is_expected.to permit_args(:update_with, params) }
       end
 
-      context 'package is not used' do
+      context 'when package is not used' do
         let(:package) { create(:package, user_id: user.id) }
 
         it { is_expected.to permit(:destroy) }
       end
     end
 
-    context 'modyfing their assigned package' do
+    context 'when modyfing their assigned package' do
       let(:package) { user.packages.first }
 
       it { is_expected.not_to permit(:update)  }
@@ -117,7 +118,7 @@ describe PackagePolicy do
     end
   end
 
-  context 'for an admin' do
+  context 'when being an admin' do
     let(:user) { FactoryGirl.create(:admin) }
 
     it { is_expected.to permit(:show)    }
@@ -126,3 +127,4 @@ describe PackagePolicy do
     it { is_expected.to permit(:destroy) }
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups

--- a/spec/policies/package_policy_spec.rb
+++ b/spec/policies/package_policy_spec.rb
@@ -6,10 +6,10 @@ require File.expand_path('../spec_helper.rb', __dir__)
 describe PackagePolicy do
   subject { described_class.new(user, package) }
 
-  let(:package) { FactoryGirl.create(:package, name: 'testpackage') }
+  let(:package) { FactoryBot.create(:package, name: 'testpackage') }
 
   context 'when being a user' do
-    let(:user) { FactoryGirl.create(:user) }
+    let(:user) { FactoryBot.create(:user) }
 
     context 'when user has booked this package' do
       let(:package) { user.packages.first }
@@ -27,7 +27,7 @@ describe PackagePolicy do
   end
 
   context 'when being a reseller' do
-    let(:user) { FactoryGirl.create(:reseller) }
+    let(:user) { FactoryBot.create(:reseller) }
 
     context 'when user has booked this package' do
       let(:package) { user.packages.first }
@@ -119,7 +119,7 @@ describe PackagePolicy do
   end
 
   context 'when being an admin' do
-    let(:user) { FactoryGirl.create(:admin) }
+    let(:user) { FactoryBot.create(:admin) }
 
     it { is_expected.to permit(:show)    }
     it { is_expected.to permit(:create)  }

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require File.expand_path '../../spec_helper.rb', __FILE__
+require File.expand_path('../spec_helper.rb', __dir__)
 
+# rubocop:disable Metrics/BlockLength, RSpec/NestedGroups
 describe UserPolicy do
   subject { described_class.new(user, testuser) }
 
@@ -9,7 +10,7 @@ describe UserPolicy do
     FactoryGirl.create(:user, name: 'Testuser', login: 'testuser')
   end
 
-  context 'for the user itself' do
+  context 'when being the user itself' do
     let(:user) { testuser }
 
     it { is_expected.to permit(:show) }
@@ -18,7 +19,7 @@ describe UserPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'changing the id as an unauthorized user' do
+  context 'when changing the id as an unauthorized user' do
     let(:user) { create(:reseller_with_customers) }
     let(:testuser) { user.customers.first }
     let(:params) { attributes_for(:user, id: 1234) }
@@ -26,7 +27,7 @@ describe UserPolicy do
     it { is_expected.not_to permit_args(:update_with, params) }
   end
 
-  context 'for another unprivileged user' do
+  context 'when being another unprivileged user' do
     let(:owner) { create(:user_with_domains) }
     let(:user) { create(:user_with_domains) }
     let(:domain) { owner.domains.first }
@@ -37,7 +38,7 @@ describe UserPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for the reseller of the user' do
+  context 'when being the reseller of the user' do
     let(:user) do
       reseller = create(:reseller_with_customers)
       package = create(:reseller_package)
@@ -48,7 +49,7 @@ describe UserPolicy do
     let(:testuser) { user.customers.first }
     let(:group) { testuser.group }
 
-    context 'assigning 1 package' do
+    context 'when assigning 1 package' do
       let(:params) do
         packages = create_list(:package, 2, user_id: user.id)
         attrs = attributes_for(:user, reseller_id: user.id, group_id: group.id)
@@ -56,13 +57,13 @@ describe UserPolicy do
         attrs
       end
 
-      context 'with available quota' do
+      context 'when with available quota' do
         it { is_expected.to permit(:create) }
         it { is_expected.to permit_args(:create_with, params) }
       end
     end
 
-    context 'assigning 3 packages' do
+    context 'when assigning 3 packages' do
       let(:testuser) do
         testuser = user.customers.first
         packages = create_list(:package, 2, user_id: user.id)
@@ -77,13 +78,13 @@ describe UserPolicy do
         attrs
       end
 
-      context 'with available quota' do
+      context 'when with available quota' do
         it { is_expected.to permit(:create) }
         it { is_expected.to permit_args(:create_with, params) }
       end
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) { create(:reseller_with_exhausted_customer_quota) }
 
       it { is_expected.not_to permit(:create) }
@@ -94,7 +95,7 @@ describe UserPolicy do
     it { is_expected.to permit(:destroy) }
   end
 
-  context 'for another unprivileged reseller' do
+  context 'when being another unprivileged reseller' do
     let(:owner) { create(:reseller, name: 'Reseller', login: 'reseller') }
     let(:user) { create(:reseller, name: 'Reseller2', login: 'reseller2') }
     let(:testuser) do
@@ -104,11 +105,11 @@ describe UserPolicy do
              reseller_id: owner.id)
     end
 
-    context 'with available quota' do
+    context 'when with available quota' do
       it { is_expected.to permit(:create) }
     end
 
-    context 'with exhausted quota' do
+    context 'when with exhausted quota' do
       let(:user) { create(:reseller_with_exhausted_customer_quota) }
 
       it { is_expected.not_to permit(:create) }
@@ -119,7 +120,7 @@ describe UserPolicy do
     it { is_expected.not_to permit(:destroy) }
   end
 
-  context 'for an admin' do
+  context 'when being an admin' do
     let(:user) { create(:admin) }
 
     it { is_expected.to permit(:show) }
@@ -128,3 +129,4 @@ describe UserPolicy do
     it { is_expected.to permit(:destroy) }
   end
 end
+# rubocop:enable Metrics/BlockLength, RSpec/NestedGroups

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -7,7 +7,7 @@ describe UserPolicy do
   subject { described_class.new(user, testuser) }
 
   let(:testuser) do
-    FactoryGirl.create(:user, name: 'Testuser', login: 'testuser')
+    FactoryBot.create(:user, name: 'Testuser', login: 'testuser')
   end
 
   context 'when being the user itself' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,14 +14,14 @@ require 'simplecov'
 # end
 # SimpleCov.start 'vhost-api'
 
-require File.expand_path '../../vhost_api_app.rb', __FILE__
+require File.expand_path('../vhost_api_app.rb', __dir__)
 require 'rspec'
 require 'rack/test'
 require 'factory_girl'
 require 'database_cleaner'
-require File.expand_path '../support/pundit_matcher.rb', __FILE__
-require File.expand_path '../support/auth_helper.rb', __FILE__
-require File.expand_path '../support/format_helper.rb', __FILE__
+require File.expand_path('support/pundit_matcher.rb', __dir__)
+require File.expand_path('support/auth_helper.rb', __dir__)
+require File.expand_path('support/format_helper.rb', __dir__)
 
 ENV['RACK_ENV'] = 'test'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require 'simplecov'
 require File.expand_path('../vhost_api_app.rb', __dir__)
 require 'rspec'
 require 'rack/test'
-require 'factory_girl'
+require 'factory_bot'
 require 'database_cleaner'
 require File.expand_path('support/pundit_matcher.rb', __dir__)
 require File.expand_path('support/auth_helper.rb', __dir__)
@@ -34,12 +34,12 @@ end
 
 RSpec.configure do |c|
   c.include RSpecMixin
-  c.include FactoryGirl::Syntax::Methods
+  c.include FactoryBot::Syntax::Methods
   c.include AuthHelpers
   c.include FormatHelpers
 
   c.before(:suite) do
-    FactoryGirl.find_definitions
+    FactoryBot.find_definitions
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
   end

--- a/spec/support/format_helper.rb
+++ b/spec/support/format_helper.rb
@@ -22,7 +22,7 @@ module FormatHelpers
       result = spec_limited_collection(collection: object, params: params)
     rescue DataObjects::DataError, ArgumentError
       spec_api_error(ApiErrors.[](:invalid_query))
-    rescue
+    rescue Error
       spec_api_error(ApiErrors.[](:invalid_request))
     end
 

--- a/spec/support/pundit_matcher.rb
+++ b/spec/support/pundit_matcher.rb
@@ -18,7 +18,9 @@ end
 
 RSpec::Matchers.define :permit_args do |action, args|
   match do |policy|
+    # rubocop:disable Lint/UnneededSplatExpansion
     policy.public_send("#{action}?", *[args])
+    # rubocop:enable Lint/UnneededSplatExpansion
   end
 
   failure_message do |policy|

--- a/tasks/db.rake
+++ b/tasks/db.rake
@@ -18,6 +18,7 @@ begin
                       @dbconfig[:db_name]].join)
   end
 
+  # rubocop:disable Metrics/BlockLength
   namespace :db do
     setup_dm
 
@@ -69,8 +70,7 @@ begin
           query = [
             'mysql', '-B', '--skip-pager', '--user=' + user.to_s,
             (password.empty? ? '' : '--password=' + password.to_s),
-            (%w[127.0.0.1 localhost].include?(host) ? '-e' : '--host=' +
-            host.to_s + ' -e'),
+            ('--host=' + host.to_s + ' -e'),
             'CREATE DATABASE ' + database.to_s + ' DEFAULT CHARACTER SET ' +
               charset.to_s + ' DEFAULT COLLATE ' + collation.to_s
           ]
@@ -100,8 +100,7 @@ begin
           query = [
             'mysql', '-B', '--skip-pager', '--user=' + user.to_s,
             (password.empty? ? '' : '--password=' + password.to_s),
-            (%w[127.0.0.1 localhost].include?(host) ? '-e' : '--host=' +
-            host.to_s + ' -e'),
+            ('--host=' + host.to_s + ' -e'),
             'DROP DATABASE IF EXISTS ' + database.to_s
           ]
           system(query.compact.join(' '))
@@ -124,4 +123,5 @@ begin
     desc 'Create the database, migrate and init with the seed data'
     task setup: %i[create migrate seed]
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/vhost_api_app.rb
+++ b/vhost_api_app.rb
@@ -24,12 +24,14 @@ configure do
   set :api_version, 'v1'
   use Rack::TempfileReaper
   use Rack::Deflater
-  set :root, File.expand_path('../', __FILE__)
+  set :root, File.expand_path(__dir__)
   set :start_time, Time.now
   set :logging, false
+  # rubocop:disable Security/YAMLLoad
   @appconfig = YAML.load(
     File.read("#{settings.root}/config/appconfig.yml")
   )[settings.environment.to_s]
+  # rubocop:enable Security/YAMLLoad
   @appconfig.keys.each do |key|
     set key, @appconfig[key]
   end


### PR DESCRIPTION
Rather large PR, sorry....

- update gems
- set rubocop target to ruby 2.5
- fix rubocop warnings
- fix errors due to gem updates (Rack::Deflate dropped "deflate" encoding support)
- switch from factory_girl to factory_bot (former is deprecated)
- monkey patch an initialization sequence in datamapper to fix deprecation warnings